### PR TITLE
test: getRandomInteger unit test does not cover custom min/max ranges

### DIFF
--- a/src/number/__tests__/getRandomInteger.test.ts
+++ b/src/number/__tests__/getRandomInteger.test.ts
@@ -1,25 +1,36 @@
 import { getRandomInteger } from '../getRandomInteger'
 
 describe('getRandomInteger', () => {
-	it.each([
-		{
-			name: 'gets integer with default min and max',
-			expected: {
-				min: -Number.MAX_SAFE_INTEGER,
-				max: Number.MAX_SAFE_INTEGER,
-			},
-		},
-		{
-			name: 'gets integer with reversed min and max',
-			expected: {
-				min: -Number.MAX_SAFE_INTEGER,
-				max: Number.MAX_SAFE_INTEGER,
-			},
-		},
-	])('$name', ({ expected }) => {
-		const int = getRandomInteger()
-		expect(int).toBeGreaterThanOrEqual(expected.min)
-		expect(int).toBeLessThanOrEqual(expected.max)
-		expect(Number.isInteger(int)).toBeTruthy()
+	it('returns an integer within the default range', () => {
+		const result = getRandomInteger()
+		expect(Number.isInteger(result)).toBe(true)
+		expect(result).toBeGreaterThanOrEqual(-Number.MAX_SAFE_INTEGER)
+		expect(result).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER)
+	})
+
+	it('returns an integer within an explicit range', () => {
+		const result = getRandomInteger(5, 10)
+		expect(Number.isInteger(result)).toBe(true)
+		expect(result).toBeGreaterThanOrEqual(5)
+		expect(result).toBeLessThanOrEqual(10)
+	})
+
+	it('normalizes reversed min/max', () => {
+		const result = getRandomInteger(10, 5)
+		expect(Number.isInteger(result)).toBe(true)
+		expect(result).toBeGreaterThanOrEqual(5)
+		expect(result).toBeLessThanOrEqual(10)
+	})
+
+	it('returns the only possible value when min equals max', () => {
+		expect(getRandomInteger(7, 7)).toBe(7)
+	})
+
+	it('produces all values in a small range over many iterations', () => {
+		const seen = new Set<number>()
+		for (let i = 0; i < 1000; i++) {
+			seen.add(getRandomInteger(0, 4))
+		}
+		expect(seen.size).toBe(5)
 	})
 })


### PR DESCRIPTION
## Summary
The existing `getRandomInteger` test suite contained two redundant cases that both called the function with no arguments and checked only against `MAX_SAFE_INTEGER` bounds. This PR replaces them with a meaningful suite that covers all documented behaviours.

## Changes
- `src/number/__tests__/getRandomInteger.test.ts` — rewrote the test suite with five focused cases: default range, explicit range, reversed min/max (normalization), equal min/max, and a distribution check over 1 000 iterations that verifies all values in a small range are reachable

## Test plan
- [ ] `yarn test:ci` passes with all 161 tests green
- [ ] New case `getRandomInteger(5, 10)` asserts result in `[5, 10]`
- [ ] New case `getRandomInteger(10, 5)` asserts result in `[5, 10]` (normalization via `normalizeMinMax`)
- [ ] New case `getRandomInteger(7, 7)` always returns `7`
- [ ] Distribution case runs 1 000 iterations over `[0, 4]` and asserts all 5 values were seen

Closes #36