### PR TITLE
chore: add coverage thresholds to vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,13 @@ export default defineConfig({
 			provider: 'v8',
 			reportsDirectory: './coverage',
 			include: ['src/**'],
+			exclude: ['src/index.ts'],
+			thresholds: {
+				statements: 95,
+				branches: 90,
+				functions: 95,
+				lines: 95,
+			},
 		},
 	},
 })


### PR DESCRIPTION
## Summary
Adds coverage thresholds to the Vitest config so CI fails when coverage drops below the defined floor. The barrel file `src/index.ts` is excluded from coverage since it contains no logic — only re-exports — and was pulling the overall percentages down.

## Changes
- `vite.config.ts` — added `exclude: ['src/index.ts']` and `thresholds` block to `test.coverage`:
  - `statements`: 95%
  - `branches`: 90%
  - `functions`: 95%
  - `lines`: 95%

## Test plan
- [ ] `yarn test:ci` passes with all thresholds satisfied (actual: statements 100%, branches 98%, functions 100%, lines 100%)
- [ ] `yarn build` produces clean output
- [ ] Adding a new utility without tests would now fail CI on the `statements`/`lines` threshold

Closes #38