### PR TITLE
chore: Add tsc --noEmit type-check step to CI and pre-commit hook

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: '24'
       - run: yarn install
+      - run: yarn typecheck
       - run: yarn test:ci
       - run: yarn build
       - run: npx semantic-release

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-vitest run && yarn prettier && yarn lint
+vitest run && yarn prettier && yarn lint && yarn typecheck

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"test:ci": "vitest run --coverage && yarn lint",
 		"build": "vite build && tsc -p tsconfig.build.json",
 		"lint": "eslint \"src/**/*.ts\"",
+		"typecheck": "tsc --noEmit",
 		"prettier": "prettier \"src/**/*.ts\" --ignore-path ./.prettierignore --write && git add . && git status",
 		"prepare": "husky"
 	}


### PR DESCRIPTION
## Summary

Adds a dedicated `typecheck` script that runs `tsc --noEmit` against the main `tsconfig.json`, which includes test files. Unlike `tsconfig.build.json` used by `yarn build`, the main config covers `src/**/__tests__/**/*.ts`, making type errors in test files visible to tooling.

## Changes

- `package.json` — new `typecheck` script: `tsc --noEmit`
- `.husky/pre-commit` — `yarn typecheck` appended to the pre-commit chain
- `.github/workflows/publish.yml` — `yarn typecheck` step added before `yarn test:ci`

## Test plan

- [ ] `yarn typecheck` exits 0
- [ ] `yarn test:ci` passes (174 tests + lint)
- [ ] `yarn build` succeeds
- [ ] Pre-commit hook runs typecheck on staged commits
- [ ] Introducing a type error in a test file is caught by `yarn typecheck` but not by `yarn build`

Closes #40