### PR TITLE
chore: Fix prettier script staging unrelated files

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 		"build": "vite build && tsc -p tsconfig.build.json",
 		"lint": "eslint \"src/**/*.ts\"",
 		"typecheck": "tsc --noEmit",
-		"prettier": "prettier \"src/**/*.ts\" --ignore-path ./.prettierignore --write && git add . && git status",
+		"prettier": "prettier \"src/**/*.ts\" --ignore-path ./.prettierignore --write && git add src/**/*.ts && git status",
 		"prepare": "husky"
 	}
 }


### PR DESCRIPTION
## Summary

The `prettier` npm script was using `git add .` after formatting, which staged every file with working-tree changes — not just the files touched by Prettier. This could silently include env files, generated artifacts, or accidental edits in the next commit.

## Changes

- `package.json` — replace `git add .` with `git add src/**/*.ts` in the `prettier` script, scoping the stage to only the files Prettier operates on

## Test plan

- [ ] Run `yarn prettier` with an unrelated file modified in the working tree — verify it is not staged
- [ ] `yarn test:ci` passes
- [ ] `yarn build` succeeds
- [ ] `yarn typecheck` passes

Closes #41