### PR TITLE
chore: Bump GitHub Actions to v6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '24'
           cache: 'yarn'
@@ -27,6 +27,6 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6.0.0
         with:
           files: coverage/lcov.info


### PR DESCRIPTION
## Summary

Bumps all three GitHub Actions used in the publish workflow from their current versions to the latest v6 releases. Release notes were reviewed for each action — no breaking changes apply to this workflow configuration.

## Changes

- `.github/workflows/publish.yml`
  - `actions/checkout`: `v4` → `v6.0.2`
  - `actions/setup-node`: `v4` → `v6.4.0`
  - `codecov/codecov-action`: `v5` → `v6.0.0`

## Breaking changes analysis

| Action | Breaking change | Impact |
|---|---|---|
| `checkout@v6` | Credentials stored under `$RUNNER_TEMP` instead of git config (requires runner v2.329.0+) | No impact — we don't use Docker container actions or explicit `persist-credentials` |
| `setup-node@v5` | Auto-cache when `packageManager` field present in `package.json` | No impact — our `package.json` has no `packageManager` field |
| `setup-node@v6` | Auto-cache limited to npm only | No impact — we use explicit `cache: 'yarn'` |
| `codecov-action@v6` | Runs on Node 24 | No impact — our CI already pins Node 24 |

## Test plan

- [ ] CI workflow runs successfully on push to `main`
- [ ] All steps pass (typecheck, test:ci, build, release, codecov upload)

Closes #55