### PR TITLE
docs: Fix misleading JSDoc example in removeElement

### DIFF
--- a/src/dom/removeElement.ts
+++ b/src/dom/removeElement.ts
@@ -13,7 +13,7 @@ import { isString } from '../string/isString'
  * element.className = 'foo'
  * document.body.appendChild(element)
  *
- * removeElement(element) // <div class="foo"></div>
+ * removeElement(element) // returns the detached <div class="foo"></div>
  *
  * @param element  - The DOM element or the selector of the DOM element to remove.
  * @returns The removed DOM element.


### PR DESCRIPTION
## Summary

The JSDoc example for `removeElement` showed the element's HTML representation in a comment, which could be misread as the element still being present in the DOM. The function actually detaches the node and returns it.

## Changes

- `src/dom/removeElement.ts` — updated example comment from `// <div class="foo"></div>` to `// returns the detached <div class="foo"></div>`

## Test plan

- [ ] `yarn test:ci` passes
- [ ] `yarn build` succeeds (TypeDoc generates correct documentation)

Closes #43