### PR TITLE
fix: Correct generateTokenizedText JSDoc example to use config-object API

### DIFF
--- a/src/string/generateTokenizedText.ts
+++ b/src/string/generateTokenizedText.ts
@@ -30,7 +30,7 @@ export interface GenerateTokenizedTextConfig {
  * const minWords = 5
  * const maxWords = 10
  * const dictionary = ['foo', 'bar', 'gag']
- * generateTokenizedText(tokens, divider, minWords, maxWords, dictionary) // {indices: Array(3), text: "foo $pol$ $biz$ bar gag $kuy$ foo gag foo"}}
+ * generateTokenizedText({ tokens, divider, minWords, maxWords, dictionary }) // {indices: Array(3), text: "foo $pol$ $biz$ bar gag $kuy$ foo gag foo"}
  *
  * @param config - The configuration object for the text generation.
  * @returns An object containing a list of token indices and the generated string.


### PR DESCRIPTION
## Summary

The JSDoc example for `generateTokenizedText` was using the old positional-parameter call form, which no longer matches the function signature. Developers following the example would pass positional arguments to a function that expects a single config object, resulting in unexpected behavior at runtime.

## Changes

- `src/string/generateTokenizedText.ts` — updated example call from `generateTokenizedText(tokens, divider, minWords, maxWords, dictionary)` to `generateTokenizedText({ tokens, divider, minWords, maxWords, dictionary })`

## Test plan

- [ ] `yarn test:ci` passes
- [ ] `yarn build` succeeds (TypeDoc generates correct documentation)
- [ ] Generated IDE hover docs show the correct call form

Closes #35