### PR TITLE
refactor(string)!: Replace new Function with regex in interpolateLiteral

### DIFF
--- a/src/string/__tests__/interpolateLiteral.test.ts
+++ b/src/string/__tests__/interpolateLiteral.test.ts
@@ -12,38 +12,20 @@ describe('interpolateLiteral', () => {
 				fun: 'dignity',
 			},
 			expected: 'A bird with fun "wings" and a lot of dignity'
-		},
-		{
-			name: 'interpolates token with null value as "null"',
-			value: 'A ${foo} and ${bar}',
-			tokens: {
-				foo: 'bird',
-				bar: null,
-			},
-			expected: 'A bird and null'
-		},
-		{
-			name: 'interpolates token with undefined value as "undefined"',
-			value: 'A ${foo} and ${bar}',
-			tokens: {
-				foo: 'bird',
-				bar: undefined,
-			},
-			expected: 'A bird and undefined'
-		},
-		{
-			name: 'interpolates token with Symbol value as its string representation',
-			value: 'A ${foo} and ${bar}',
-			tokens: {
-				foo: 'bird',
-				bar: Symbol('sym'),
-			},
-			expected: 'A bird and Symbol(sym)'
 		}
 	])('$name', ({value, tokens, expected}) => {
 		expect(
-			interpolateLiteral(value, tokens as Record<string, unknown>)
+			interpolateLiteral(value, tokens)
 		).toBe(expected)
+	})
+
+	// prettier-ignore
+	it.each([
+		{ bar: null,           expected: 'null'        },
+		{ bar: undefined,      expected: 'undefined'   },
+		{ bar: Symbol('sym'),  expected: 'Symbol(sym)' },
+	])('coerces token value to string: $expected', ({ bar, expected }) => {
+		expect(interpolateLiteral('A ${foo} and ${bar}', { foo: 'bird', bar } as Record<string, unknown>)).toBe(`A bird and ${expected}`)
 	})
 
 	// prettier-ignore

--- a/src/string/__tests__/interpolateLiteral.test.ts
+++ b/src/string/__tests__/interpolateLiteral.test.ts
@@ -12,34 +12,51 @@ describe('interpolateLiteral', () => {
 				fun: 'dignity',
 			},
 			expected: 'A bird with fun "wings" and a lot of dignity'
+		},
+		{
+			name: 'interpolates token with null value as "null"',
+			value: 'A ${foo} and ${bar}',
+			tokens: {
+				foo: 'bird',
+				bar: null,
+			},
+			expected: 'A bird and null'
+		},
+		{
+			name: 'interpolates token with undefined value as "undefined"',
+			value: 'A ${foo} and ${bar}',
+			tokens: {
+				foo: 'bird',
+				bar: undefined,
+			},
+			expected: 'A bird and undefined'
+		},
+		{
+			name: 'interpolates token with Symbol value as its string representation',
+			value: 'A ${foo} and ${bar}',
+			tokens: {
+				foo: 'bird',
+				bar: Symbol('sym'),
+			},
+			expected: 'A bird and Symbol(sym)'
 		}
 	])('$name', ({value, tokens, expected}) => {
 		expect(
-			interpolateLiteral(value, tokens)
+			interpolateLiteral(value, tokens as Record<string, unknown>)
 		).toBe(expected)
 	})
 
 	// prettier-ignore
 	it.each([
 		{
-			name: 'throws if value is not stringifiable',
+			name: 'throws if value is not a string',
 			value: Symbol(),
 			tokens: {
 				foo: 'bird',
 				bar: 'wings',
 				fun: 'dignity',
 			},
-			error: 'Cannot convert a Symbol value to a string'
-		},
-		{
-			name: 'throws if one of tokens is not stringifiable',
-			value: 'A ${foo} with fun "${bar}" and a lot of ${fun}',
-			tokens: {
-				foo: 'bird',
-				bar: Symbol(),
-				fun: 'dignity',
-			},
-			error: 'Cannot convert a Symbol value to a string'
+			error: 'value.replace is not a function'
 		},
 		{
 			name: 'throws if one token is missing',

--- a/src/string/__tests__/interpolateLiteral.test.ts
+++ b/src/string/__tests__/interpolateLiteral.test.ts
@@ -38,7 +38,7 @@ describe('interpolateLiteral', () => {
 				bar: 'wings',
 				fun: 'dignity',
 			},
-			error: 'value.replace is not a function'
+			error: TypeError
 		},
 		{
 			name: 'throws if one token is missing',

--- a/src/string/interpolateLiteral.ts
+++ b/src/string/interpolateLiteral.ts
@@ -21,7 +21,7 @@
  */
 export const interpolateLiteral = (value: string, tokens: Record<string, unknown>): string => {
 	return value.replace(/\$\{(\w+)\}/g, (_, key) => {
-		if (!(key in tokens)) throw new ReferenceError(`${key} is not defined`)
+		if (!Object.hasOwn(tokens, key)) throw new ReferenceError(`${key} is not defined`)
 		return String(tokens[key])
 	})
 }

--- a/src/string/interpolateLiteral.ts
+++ b/src/string/interpolateLiteral.ts
@@ -16,10 +16,12 @@
  * interpolateLiteral(value, tokens) // A bird with 3 "wings" and a lot of dignity
  *
  * @param value   - The literal-like string value to interpolate.
- * @param tokens  - An object of key/value pairs to replace the tokens.
+ * @param tokens  - An object of key/value pairs to replace the tokens. Keys must be valid identifiers (`\w+`).
  * @returns The interpolated string.
  */
 export const interpolateLiteral = (value: string, tokens: Record<string, unknown>): string => {
-	const fn = new Function(...Object.keys(tokens), `return \`${value}\``)
-	return fn(...Object.values(tokens)) as string
+	return value.replace(/\$\{(\w+)\}/g, (_, key) => {
+		if (!(key in tokens)) throw new ReferenceError(`${key} is not defined`)
+		return String(tokens[key])
+	})
 }


### PR DESCRIPTION
## Summary

Eliminates the `new Function` / `eval`-based implementation in `interpolateLiteral`, replacing it with a CSP-safe regex substitution that matches `${key}` placeholders against the `tokens` object.

## Changes

- `src/string/interpolateLiteral.ts` — rewrite using `.replace(/\$\{(\w+)\}/g, ...)`, no dynamic code generation
- `src/string/__tests__/interpolateLiteral.test.ts` — update error case for non-string `value`; add cases for `null`/`undefined`/Symbol token values

## ⚠️ Breaking changes

- **Symbol token values**: previously threw `TypeError: Cannot convert a Symbol value to a string` (template literal side-effect); now returns the Symbol's string representation via `String()` (e.g. `"Symbol(sym)"`).
- **Non-string `value` input** (outside TypeScript contract): error message changes from `Cannot convert a Symbol value to a string` to `value.replace is not a function`.
- **Expression placeholders** (`${foo + bar}`, `${obj.prop}`): were never documented but accidentally worked via `new Function`; no longer matched by the `\w+` regex — intentional.

## Test plan

- [x] `yarn test:ci` — 176 tests, all passing
- [x] `yarn build` — clean build

Closes #37