### PR TITLE
fix(object)!: Make deepMerge immutable by default, add mutate flag

### DIFF
--- a/src/object/__tests__/deepMerge.test.ts
+++ b/src/object/__tests__/deepMerge.test.ts
@@ -63,4 +63,20 @@ describe('deepMerge', () => {
 		expect(result).not.toBe(source)
 		expect(result).not.toBe(target)
 	})
+
+	describe('mutate: true', () => {
+		it('returns the target object itself', () => {
+			const source = { foo: 1 }
+			const target = { bar: 2 }
+			const result = deepMerge(source, target, true)
+			expect(result).toBe(target)
+		})
+
+		it('mutates target in place', () => {
+			const source = { foo: 1, bar: { baz: 2 } }
+			const target: Record<string, unknown> = { foo: 2, bar: { qux: 3 } }
+			deepMerge(source, target, true)
+			expect(target).toEqual({ foo: 1, bar: { baz: 2, qux: 3 } })
+		})
+	})
 })

--- a/src/object/__tests__/deepMerge.test.ts
+++ b/src/object/__tests__/deepMerge.test.ts
@@ -46,19 +46,13 @@ describe('deepMerge', () => {
 		expect(deepMerge(source, target)).toEqual(expected)
 	})
 
-	it('does not mutate source', () => {
+	it('does not mutate source or target', () => {
 		const source = { foo: 1, bar: { baz: 2 } }
 		const target = { foo: 2, bar: { qux: 3 } }
 		const sourceBefore = structuredClone(source)
-		deepMerge(source, target)
-		expect(source).toEqual(sourceBefore)
-	})
-
-	it('does not mutate target', () => {
-		const source = { foo: 1, bar: { baz: 2 } }
-		const target = { foo: 2, bar: { qux: 3 } }
 		const targetBefore = structuredClone(target)
 		deepMerge(source, target)
+		expect(source).toEqual(sourceBefore)
 		expect(target).toEqual(targetBefore)
 	})
 

--- a/src/object/__tests__/deepMerge.test.ts
+++ b/src/object/__tests__/deepMerge.test.ts
@@ -45,4 +45,28 @@ describe('deepMerge', () => {
 	])('$name', ({ source, target, expected }) => {
 		expect(deepMerge(source, target)).toEqual(expected)
 	})
+
+	it('does not mutate source', () => {
+		const source = { foo: 1, bar: { baz: 2 } }
+		const target = { foo: 2, bar: { qux: 3 } }
+		const sourceBefore = structuredClone(source)
+		deepMerge(source, target)
+		expect(source).toEqual(sourceBefore)
+	})
+
+	it('does not mutate target', () => {
+		const source = { foo: 1, bar: { baz: 2 } }
+		const target = { foo: 2, bar: { qux: 3 } }
+		const targetBefore = structuredClone(target)
+		deepMerge(source, target)
+		expect(target).toEqual(targetBefore)
+	})
+
+	it('returns a new object distinct from both source and target', () => {
+		const source = { foo: 1 }
+		const target = { bar: 2 }
+		const result = deepMerge(source, target)
+		expect(result).not.toBe(source)
+		expect(result).not.toBe(target)
+	})
 })

--- a/src/object/__tests__/deepMerge.test.ts
+++ b/src/object/__tests__/deepMerge.test.ts
@@ -78,5 +78,14 @@ describe('deepMerge', () => {
 			deepMerge(source, target, true)
 			expect(target).toEqual({ foo: 1, bar: { baz: 2, qux: 3 } })
 		})
+
+		it('does not alias nested source objects into target', () => {
+			const nested = { baz: 1 }
+			const source = { foo: nested }
+			const target: Record<string, unknown> = {}
+			deepMerge(source, target, true)
+			expect(target.foo).not.toBe(nested)
+			expect(target.foo).toEqual(nested)
+		})
 	})
 })

--- a/src/object/__tests__/deepMerge.test.ts
+++ b/src/object/__tests__/deepMerge.test.ts
@@ -64,6 +64,14 @@ describe('deepMerge', () => {
 		expect(result).not.toBe(target)
 	})
 
+	it('does not alias nested source objects into result', () => {
+		const nested = { baz: 1 }
+		const source = { foo: nested }
+		const result = deepMerge(source, {})
+		expect(result.foo).not.toBe(nested)
+		expect(result.foo).toEqual(nested)
+	})
+
 	describe('mutate: true', () => {
 		it('returns the target object itself', () => {
 			const source = { foo: 1 }

--- a/src/object/deepMerge.ts
+++ b/src/object/deepMerge.ts
@@ -15,20 +15,19 @@ import { isObject } from './isObject'
  *
  * @param source - The object to merge into the target.
  * @param target - The target object where source will be merged.
- * @returns The target object containing both source and target keys with source precedence.
+ * @returns A new object containing both source and target keys with source precedence.
  */
 export const deepMerge = (
 	source: Record<string, unknown>,
 	target: Record<string, unknown>
 ): Record<string, unknown> => {
+	const result = structuredClone(target)
 	for (const key of Object.keys(source)) {
-		if (isObject(source[key]) && key in target) {
-			Object.assign(
-				source[key] as Record<string, unknown>,
-				deepMerge(source[key] as Record<string, unknown>, target[key] as Record<string, unknown>)
-			)
+		if (isObject(source[key]) && key in result && isObject(result[key])) {
+			result[key] = deepMerge(source[key] as Record<string, unknown>, result[key] as Record<string, unknown>)
+		} else {
+			result[key] = source[key]
 		}
 	}
-	Object.assign(target || {}, source)
-	return target
+	return result
 }

--- a/src/object/deepMerge.ts
+++ b/src/object/deepMerge.ts
@@ -32,7 +32,7 @@ export const deepMerge = (
 				mutate
 			)
 		} else {
-			result[key] = source[key]
+			result[key] = mutate && isObject(source[key]) ? structuredClone(source[key]) : source[key]
 		}
 	}
 	return result

--- a/src/object/deepMerge.ts
+++ b/src/object/deepMerge.ts
@@ -32,7 +32,7 @@ export const deepMerge = (
 				mutate
 			)
 		} else {
-			result[key] = mutate && isObject(source[key]) ? structuredClone(source[key]) : source[key]
+			result[key] = isObject(source[key]) ? structuredClone(source[key]) : source[key]
 		}
 	}
 	return result

--- a/src/object/deepMerge.ts
+++ b/src/object/deepMerge.ts
@@ -23,7 +23,7 @@ export const deepMerge = (
 ): Record<string, unknown> => {
 	const result = structuredClone(target)
 	for (const key of Object.keys(source)) {
-		if (isObject(source[key]) && key in result && isObject(result[key])) {
+		if (key in result && isObject(source[key]) && isObject(result[key])) {
 			result[key] = deepMerge(source[key] as Record<string, unknown>, result[key] as Record<string, unknown>)
 		} else {
 			result[key] = source[key]

--- a/src/object/deepMerge.ts
+++ b/src/object/deepMerge.ts
@@ -15,16 +15,22 @@ import { isObject } from './isObject'
  *
  * @param source - The object to merge into the target.
  * @param target - The target object where source will be merged.
- * @returns A new object containing both source and target keys with source precedence.
+ * @param mutate - If true, merges directly into target without cloning. Defaults to false.
+ * @returns The merged object — a new object when mutate is false, target itself when mutate is true.
  */
 export const deepMerge = (
 	source: Record<string, unknown>,
-	target: Record<string, unknown>
+	target: Record<string, unknown>,
+	mutate = false
 ): Record<string, unknown> => {
-	const result = structuredClone(target)
+	const result = mutate ? target : structuredClone(target)
 	for (const key of Object.keys(source)) {
 		if (key in result && isObject(source[key]) && isObject(result[key])) {
-			result[key] = deepMerge(source[key] as Record<string, unknown>, result[key] as Record<string, unknown>)
+			result[key] = deepMerge(
+				source[key] as Record<string, unknown>,
+				result[key] as Record<string, unknown>,
+				mutate
+			)
 		} else {
 			result[key] = source[key]
 		}


### PR DESCRIPTION
## Summary

Rewrites `deepMerge` to be immutable by default, and adds an optional `mutate` flag to preserve in-place merging when needed.

- **Default (`mutate = false`)**: builds a fresh result from `structuredClone(target)` — neither `source` nor `target` is touched
- **`mutate = true`**: merges `source` directly into `target` and returns `target` itself; nested source objects for keys absent from `target` are cloned to prevent source aliasing

## Changes

- `src/object/deepMerge.ts` — immutable rewrite + `mutate` parameter (default `false`); JSDoc updated
- `src/object/__tests__/deepMerge.test.ts` — new assertions: source/target not mutated, result is distinct object, `mutate: true` returns target, mutates in place, does not alias nested source objects

## ⚠️ Breaking changes

- **Return value is a new object**: `deepMerge(s, t) !== t`. Previously the function mutated `target` and returned the same reference. Code relying on `deepMerge(s, t) === t` or on post-call inspection of `t` must use the returned value instead — or pass `mutate: true` to restore the old behaviour.

## Test plan

- [x] `yarn test:ci` — 179 tests, all passing
- [x] `yarn build` — clean build

Closes #30