### PR TITLE
fix(dom): Replace for...in with Object.entries on attributes in modifyElement

### DIFF
--- a/src/dom/__tests__/modifyElement.test.ts
+++ b/src/dom/__tests__/modifyElement.test.ts
@@ -54,6 +54,15 @@ describe('modifyElement', () => {
 		expect(modifyElement(getElement(), attributes)).toContainHTML(expected)
 	})
 
+	it('does not apply inherited enumerable properties from attributes prototype', () => {
+		const proto = { 'data-inherited': 'bad' }
+		const attributes = Object.create(proto) as Record<string, string>
+		attributes['data-own'] = 'good'
+		modifyElement(el as HTMLElement, attributes)
+		expect(el?.getAttribute('data-own')).toBe('good')
+		expect(el?.hasAttribute('data-inherited')).toBe(false)
+	})
+
 	// prettier-ignore
 	it.each([
 		{

--- a/src/dom/modifyElement.ts
+++ b/src/dom/modifyElement.ts
@@ -24,11 +24,11 @@ export const modifyElement = (
 	attributes: Record<string, string | null | undefined> = {}
 ): HTMLElement | null => {
 	const el: HTMLElement | null = isString(element) ? document.querySelector<HTMLElement>(element) : element
-	for (const z in attributes) {
-		if (attributes[z] === undefined || attributes[z] === null) {
-			el?.removeAttribute(z)
+	for (const [key, value] of Object.entries(attributes)) {
+		if (value === undefined || value === null) {
+			el?.removeAttribute(key)
 		} else {
-			el?.setAttribute(z, attributes[z] as string)
+			el?.setAttribute(key, value)
 		}
 	}
 	return el


### PR DESCRIPTION
## Summary

Fixes prototype-chain iteration in \`modifyElement\` when processing the \`attributes\` object. \`for...in\` walks inherited enumerable properties in addition to own ones; \`Object.entries\` restricts iteration to own enumerable properties.

Note: \`createElement\` was already using \`Object.entries\` — only \`modifyElement\` required the fix.

## Changes

- \`src/dom/modifyElement.ts\` — replace \`for (const z in attributes)\` with \`for (const [key, value] of Object.entries(attributes))\`
- \`src/dom/__tests__/modifyElement.test.ts\` — add test: attributes object with inherited enumerable property does not apply that property to the element

## Test plan

- [x] \`yarn test:ci\` — 183 tests, all passing
- [x] New test: prototype-inherited attribute is not applied to the DOM element

## ⚠️ Breaking changes

None — only affects the previously broken behaviour (prototype-polluted attributes objects).

Closes #32