### PR TITLE
fix(string): Replace incomplete escapeDivider regex with full metacharacter set

### DIFF
--- a/src/string/__tests__/interpolate.test.ts
+++ b/src/string/__tests__/interpolate.test.ts
@@ -54,6 +54,27 @@ describe('interpolate', () => {
 			divider: '<%=',
 			expected: 'A bird with fun "<%=bar<%=" and a lot of dignity',
 		},
+		{
+			name: 'interpolates value with { as divider',
+			value: 'A {foo{ with fun "{bar{" and a lot of {fun{',
+			tokens: { foo: 'bird', bar: 'wings', fun: 'dignity' },
+			divider: '{',
+			expected: 'A bird with fun "wings" and a lot of dignity',
+		},
+		{
+			name: 'interpolates value with } as divider',
+			value: 'A }foo} with fun "}bar}" and a lot of }fun}',
+			tokens: { foo: 'bird', bar: 'wings', fun: 'dignity' },
+			divider: '}',
+			expected: 'A bird with fun "wings" and a lot of dignity',
+		},
+		{
+			name: 'interpolates value with \\ as divider',
+			value: 'A \\foo\\ with fun "\\bar\\" and a lot of \\fun\\',
+			tokens: { foo: 'bird', bar: 'wings', fun: 'dignity' },
+			divider: '\\',
+			expected: 'A bird with fun "wings" and a lot of dignity',
+		},
 	])('$name', ({ value, tokens, divider, expected }) => {
 		expect(interpolate(value, tokens, divider)).toBe(expected)
 	})

--- a/src/string/interpolate.ts
+++ b/src/string/interpolate.ts
@@ -5,15 +5,7 @@
 import { isNil } from '../lang/isNil'
 
 /** @private */
-const escapeDivider = (divider: string): string => {
-	const regex = new RegExp('([\\[\\^\\$\\.|\\?\\*\\+\\(\\)])+', 'g')
-	return divider.replace(regex, (match) =>
-		match
-			.split('')
-			.map((i) => '\\' + i)
-			.join('')
-	)
-}
+const escapeDivider = (divider: string): string => divider.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 /** @private */
 const pipeTokens = (tokens: Record<string, unknown>): string => {


### PR DESCRIPTION
## Summary

Fixes \`escapeDivider\` in \`interpolate\` which was missing \`{\`, \`}\`, and \`\\\` from its character class. Using those characters as a divider caused \`new RegExp\` to throw or produce incorrect matches. Replaced the verbose custom implementation with the idiomatic one-liner that covers all regex metacharacters.

## Changes

- \`src/string/interpolate.ts\` — replace 8-line \`escapeDivider\` implementation with \`divider.replace(/[.*+?^${}()|[\]\\\\]/g, '\\\\$&')\`
- \`src/string/__tests__/interpolate.test.ts\` — add three test cases covering \`{\`, \`}\`, and \`\\\` as dividers

## Test plan

- [x] \`yarn test:ci\` — 185 tests, all passing
- [x] New tests: \`{\`, \`}\`, and \`\\\` dividers interpolate correctly

## ⚠️ Breaking changes

None — only affects previously broken or undefined behaviour.

Closes #34