### PR TITLE
fix(object): Deep clone non-plain-object source values in deepMerge

### DIFF
--- a/src/object/__tests__/deepMerge.test.ts
+++ b/src/object/__tests__/deepMerge.test.ts
@@ -72,6 +72,50 @@ describe('deepMerge', () => {
 		expect(result.foo).toEqual(nested)
 	})
 
+	describe('non-plain-object source values', () => {
+		it('does not alias arrays from source into result', () => {
+			const items = [1, 2]
+			const source = { items }
+			const result = deepMerge(source, {})
+			expect(result.items).not.toBe(items)
+			;(result.items as number[]).push(3)
+			expect(items).toEqual([1, 2])
+		})
+
+		it('clones Date instances from source', () => {
+			const created = new Date('2025-01-01')
+			const source = { created }
+			const result = deepMerge(source, {})
+			expect(result.created).not.toBe(created)
+			expect(result.created).toEqual(created)
+		})
+
+		it('clones Map instances from source', () => {
+			const map = new Map([['a', 1]])
+			const source = { map }
+			const result = deepMerge(source, {})
+			expect(result.map).not.toBe(map)
+			expect(result.map).toEqual(map)
+		})
+
+		it('clones Set instances from source', () => {
+			const set = new Set([1, 2, 3])
+			const source = { set }
+			const result = deepMerge(source, {})
+			expect(result.set).not.toBe(set)
+			expect(result.set).toEqual(set)
+		})
+
+		it('does not alias arrays when overwriting an existing key', () => {
+			const items = [1, 2]
+			const source = { items }
+			const result = deepMerge(source, { items: 'old' })
+			expect(result.items).not.toBe(items)
+			;(result.items as number[]).push(3)
+			expect(items).toEqual([1, 2])
+		})
+	})
+
 	describe('mutate: true', () => {
 		it('returns the target object itself', () => {
 			const source = { foo: 1 }

--- a/src/object/deepMerge.ts
+++ b/src/object/deepMerge.ts
@@ -32,7 +32,8 @@ export const deepMerge = (
 				mutate
 			)
 		} else {
-			result[key] = isObject(source[key]) ? structuredClone(source[key]) : source[key]
+			const value = source[key]
+			result[key] = value !== null && typeof value === 'object' ? structuredClone(value) : value
 		}
 	}
 	return result


### PR DESCRIPTION
## Summary
`deepMerge` (with the default `mutate = false`) only deep-cloned plain objects from `source`. Non-plain reference types (arrays, `Date`, `Map`, `Set`) were assigned **by reference**, leaking a shared reference between `source` and the returned object and breaking the immutability guarantee.

## Changes
- `src/object/deepMerge.ts` — In the assignment branch, clone any non-null object value (`typeof value === 'object'`) via `structuredClone`, not only plain objects. Functions remain passed by reference (not cloneable).
- `src/object/__tests__/deepMerge.test.ts` — Add regression tests: arrays not aliased from source (including when overwriting an existing key), and `Date`/`Map`/`Set` cloned.

## Test plan
- [ ] Mutating an array on the result does not affect the source array
- [ ] `Date`, `Map`, `Set` values from source are cloned (not the same reference)
- [ ] Existing merge behavior and `mutate: true` mode are unchanged

## Notes
- Full test suite passes single-threaded (`npx vitest run --no-file-parallelism`, all green). The previously flaky `extractByIndices.fastcheck` timeout is fixed separately in #77 / #78.

Closes #67