### PR TITLE
fix(string): Guard against omitted tokens in interpolateLiteral

### DIFF
--- a/src/string/__tests__/interpolateLiteral.test.ts
+++ b/src/string/__tests__/interpolateLiteral.test.ts
@@ -52,4 +52,13 @@ describe('interpolateLiteral', () => {
 	])('$name', ({value, tokens, error}) => {
 		expect(() => interpolateLiteral(value as unknown as string, tokens as unknown as Record<string, unknown>)).toThrow(error)
 	})
+
+	it('returns the value unchanged when tokens is omitted and no token is present', () => {
+		expect(interpolateLiteral('A plain string with no token')).toBe('A plain string with no token')
+	})
+
+	it('throws a ReferenceError (not a TypeError) when tokens is omitted and a token is present', () => {
+		expect(() => interpolateLiteral('A ${foo}')).toThrow(ReferenceError)
+		expect(() => interpolateLiteral('A ${foo}')).toThrow('foo is not defined')
+	})
 })

--- a/src/string/interpolateLiteral.ts
+++ b/src/string/interpolateLiteral.ts
@@ -16,10 +16,10 @@
  * interpolateLiteral(value, tokens) // A bird with 3 "wings" and a lot of dignity
  *
  * @param value   - The literal-like string value to interpolate.
- * @param tokens  - An object of key/value pairs to replace the tokens. Keys must be valid identifiers (`\w+`).
+ * @param tokens  - An object of key/value pairs to replace the tokens. Keys must be valid identifiers (`\w+`). Defaults to `{}`.
  * @returns The interpolated string.
  */
-export const interpolateLiteral = (value: string, tokens: Record<string, unknown>): string => {
+export const interpolateLiteral = (value: string, tokens: Record<string, unknown> = {}): string => {
 	return value.replace(/\$\{(\w+)\}/g, (_, key) => {
 		if (!Object.hasOwn(tokens, key)) throw new ReferenceError(`${key} is not defined`)
 		return String(tokens[key])


### PR DESCRIPTION
## Summary
`interpolateLiteral(value)` called without `tokens` threw a raw `TypeError: Cannot convert undefined or null to object` from `Object.hasOwn(undefined, key)` whenever the string contained a `${...}` token. This defaults `tokens` to `{}`, matching the sibling `interpolate`, so an omitted argument behaves predictably.

## Changes
- `src/string/interpolateLiteral.ts` — Default `tokens: Record<string, unknown> = {}` and update the `@param` JSDoc.
- `src/string/__tests__/interpolateLiteral.test.ts` — Add tests: omitted tokens with no token returns the string unchanged; omitted tokens with a token throws the intended `ReferenceError` (not `TypeError`).

## Test plan
- [ ] `interpolateLiteral('plain text')` returns the input unchanged
- [ ] `interpolateLiteral('A ${foo}')` throws `ReferenceError: foo is not defined`
- [ ] Existing interpolation and missing-token behavior unchanged

## Notes
- Scope is `undefined` (omitted argument), consistent with `interpolate`. An explicitly passed `null` still throws, as it does for `interpolate`; the TypeScript signature already disallows `null`/`undefined` at compile time.

Closes #68