### PR TITLE
fix(dom): Avoid unsafe DOMRect cast in createElement

### DIFF
--- a/src/dom/__tests__/createElement.test.ts
+++ b/src/dom/__tests__/createElement.test.ts
@@ -106,6 +106,13 @@ describe('createElement', () => {
 		expect(rect).toEqual({ x: 10, y: 20, left: 10, top: 20, width: 100, height: 50, right: 110, bottom: 70 })
 	})
 
+	it('derives width and height from the bounds when not provided', () => {
+		const rect = createElement({
+			boundingClientRect: { left: 10, right: 100, top: 20, bottom: 70 },
+		}).getBoundingClientRect()
+		expect(rect).toEqual({ x: 10, y: 20, left: 10, top: 20, right: 100, bottom: 70, width: 90, height: 50 })
+	})
+
 	it('exposes a toJSON method returning the rect values', () => {
 		const rect = createElement({
 			boundingClientRect: { x: 5, y: 15, width: 30, height: 40 },

--- a/src/dom/__tests__/createElement.test.ts
+++ b/src/dom/__tests__/createElement.test.ts
@@ -98,4 +98,19 @@ describe('createElement', () => {
   ])('$name', ({ values, expected }) => {
     expect(createElement(values).getBoundingClientRect()).toEqual(expected)
   })
+
+	it('derives missing rect fields from a partial boundingClientRect', () => {
+		const rect = createElement({
+			boundingClientRect: { left: 10, top: 20, width: 100, height: 50 },
+		}).getBoundingClientRect()
+		expect(rect).toEqual({ x: 10, y: 20, left: 10, top: 20, width: 100, height: 50, right: 110, bottom: 70 })
+	})
+
+	it('exposes a toJSON method returning the rect values', () => {
+		const rect = createElement({
+			boundingClientRect: { x: 5, y: 15, width: 30, height: 40 },
+		}).getBoundingClientRect()
+		expect(typeof rect.toJSON).toBe('function')
+		expect(rect.toJSON()).toEqual({ x: 5, y: 15, left: 5, top: 15, width: 30, height: 40, right: 35, bottom: 55 })
+	})
 })

--- a/src/dom/createElement.ts
+++ b/src/dom/createElement.ts
@@ -77,18 +77,22 @@ export const createElement = ({
 		parentNode.appendChild(el)
 	}
 	if (boundingClientRect) {
-		const { x, y, top, right, bottom, left, width = 0, height = 0 } = boundingClientRect
+		const { x, y, top, right, bottom, left, width, height } = boundingClientRect
 		const resolvedX = x ?? left ?? 0
 		const resolvedY = y ?? top ?? 0
+		const resolvedLeft = left ?? resolvedX
+		const resolvedTop = top ?? resolvedY
+		const resolvedWidth = width ?? (right !== undefined ? right - resolvedLeft : 0)
+		const resolvedHeight = height ?? (bottom !== undefined ? bottom - resolvedTop : 0)
 		const rect = {
 			x: resolvedX,
 			y: resolvedY,
-			width,
-			height,
-			top: top ?? resolvedY,
-			right: right ?? resolvedX + width,
-			bottom: bottom ?? resolvedY + height,
-			left: left ?? resolvedX,
+			width: resolvedWidth,
+			height: resolvedHeight,
+			top: resolvedTop,
+			right: right ?? resolvedX + resolvedWidth,
+			bottom: bottom ?? resolvedY + resolvedHeight,
+			left: resolvedLeft,
 		}
 		const domRect = Object.defineProperty({ ...rect }, 'toJSON', { value: () => ({ ...rect }) }) as DOMRect
 		el.getBoundingClientRect = () => domRect

--- a/src/dom/createElement.ts
+++ b/src/dom/createElement.ts
@@ -77,7 +77,21 @@ export const createElement = ({
 		parentNode.appendChild(el)
 	}
 	if (boundingClientRect) {
-		el.getBoundingClientRect = () => boundingClientRect as DOMRect
+		const { x, y, top, right, bottom, left, width = 0, height = 0 } = boundingClientRect
+		const resolvedX = x ?? left ?? 0
+		const resolvedY = y ?? top ?? 0
+		const rect = {
+			x: resolvedX,
+			y: resolvedY,
+			width,
+			height,
+			top: top ?? resolvedY,
+			right: right ?? resolvedX + width,
+			bottom: bottom ?? resolvedY + height,
+			left: left ?? resolvedX,
+		}
+		const domRect = Object.defineProperty({ ...rect }, 'toJSON', { value: () => ({ ...rect }) }) as DOMRect
+		el.getBoundingClientRect = () => domRect
 	}
 	return el
 }


### PR DESCRIPTION
## Summary
`createElement` assigned the raw partial `boundingClientRect` to `el.getBoundingClientRect`, casting it to `DOMRect`. Consumers reading fields that weren't explicitly provided (e.g. `x`/`y` when only `left`/`top` were given, `right`/`bottom`, or calling `toJSON()`) got `undefined`. This builds a structurally complete `DOMRect`-compatible object instead.

## Changes
- `src/dom/createElement.ts` — Resolve a full rect from the partial init: derive `x`/`y` from `left`/`top` (and vice versa), derive `right`/`bottom` from position + size, default missing values to `0`, and expose a non-enumerable `toJSON()`. Explicitly provided fields are preserved as-is (pass-through), so the existing contract is unchanged.
- `src/dom/__tests__/createElement.test.ts` — Add tests for partial-init derivation and `toJSON()`.

## Test plan
- [ ] Existing default and fully-specified `getBoundingClientRect()` cases still pass (pass-through preserved)
- [ ] A partial `{ left, top, width, height }` init derives `x`, `y`, `right`, `bottom`
- [ ] `getBoundingClientRect().toJSON()` returns the rect values

## Notes
- `toJSON` is defined as non-enumerable (mirroring a real `DOMRect`), so the existing `toEqual` assertion on the rect object is unaffected.
- A single `as DOMRect` cast remains, but it now applies to a structurally complete object rather than a partial one.

Closes #69