### PR TITLE
test(object): Expand deepMerge test coverage

### DIFF
--- a/src/object/__tests__/deepMerge.fastcheck.ts
+++ b/src/object/__tests__/deepMerge.fastcheck.ts
@@ -1,0 +1,45 @@
+import fc from 'fast-check'
+
+import { deepMerge } from '../deepMerge'
+
+const safeKey = fc.string({ minLength: 1, maxLength: 6 }).filter((key) => key !== '__proto__')
+const leaf = fc.oneof(fc.integer(), fc.string(), fc.boolean(), fc.constant(null))
+const plainObject = fc.dictionary(safeKey, fc.oneof(leaf, fc.dictionary(safeKey, leaf, { maxKeys: 5 })), {
+	maxKeys: 8,
+})
+
+describe('deepMerge (property-based)', () => {
+	it('result contains every key from source and target', () => {
+		fc.assert(
+			fc.property(plainObject, plainObject, (source, target) => {
+				const result = deepMerge(source, target)
+				for (const key of Object.keys(source)) {
+					expect(Object.hasOwn(result, key)).toBe(true)
+				}
+				for (const key of Object.keys(target)) {
+					expect(Object.hasOwn(result, key)).toBe(true)
+				}
+			})
+		)
+	})
+
+	it('does not mutate source or target when mutate is false', () => {
+		fc.assert(
+			fc.property(plainObject, plainObject, (source, target) => {
+				const sourceBefore = structuredClone(source)
+				const targetBefore = structuredClone(target)
+				deepMerge(source, target)
+				expect(source).toEqual(sourceBefore)
+				expect(target).toEqual(targetBefore)
+			})
+		)
+	})
+
+	it('returns the target reference when mutate is true', () => {
+		fc.assert(
+			fc.property(plainObject, plainObject, (source, target) => {
+				expect(deepMerge(source, target, true)).toBe(target)
+			})
+		)
+	})
+})

--- a/src/object/__tests__/deepMerge.test.ts
+++ b/src/object/__tests__/deepMerge.test.ts
@@ -116,12 +116,46 @@ describe('deepMerge', () => {
 		})
 	})
 
+	describe('merge semantics', () => {
+		it('replaces arrays instead of merging them', () => {
+			const result = deepMerge({ a: [1, 2] }, { a: [3, 4, 5] })
+			expect(result).toEqual({ a: [1, 2] })
+		})
+
+		it('merges objects nested beyond two levels', () => {
+			const source = { a: { b: { c: { d: 1 } } } }
+			const target = { a: { b: { c: { e: 2 }, x: 3 } } }
+			const result = deepMerge(source, target)
+			expect(result).toEqual({ a: { b: { c: { d: 1, e: 2 }, x: 3 } } })
+		})
+
+		it('replaces a primitive target value with an object from source', () => {
+			const result = deepMerge({ a: { b: 1 } }, { a: 5 })
+			expect(result).toEqual({ a: { b: 1 } })
+		})
+
+		it('replaces an object target value with a primitive from source', () => {
+			const result = deepMerge({ a: 5 }, { a: { b: 1 } })
+			expect(result).toEqual({ a: 5 })
+		})
+	})
+
 	describe('mutate: true', () => {
 		it('returns the target object itself', () => {
 			const source = { foo: 1 }
 			const target = { bar: 2 }
 			const result = deepMerge(source, target, true)
 			expect(result).toBe(target)
+		})
+
+		it('clones non-plain source values instead of aliasing them', () => {
+			const items = [1, 2]
+			const source = { items }
+			const target: Record<string, unknown> = {}
+			deepMerge(source, target, true)
+			expect(target.items).not.toBe(items)
+			;(target.items as number[]).push(3)
+			expect(items).toEqual([1, 2])
 		})
 
 		it('mutates target in place', () => {


### PR DESCRIPTION
## Summary
Broadens `deepMerge` test coverage with behavioral edge cases and a new property-based suite, complementing the non-aliasing regression tests already added for the clone fix.

## Changes
- `src/object/__tests__/deepMerge.test.ts` — Add cases:
  - Arrays are replaced, not merged (`{a:[1,2]}` over `{a:[3,4,5]}` → `{a:[1,2]}`)
  - Objects nested beyond two levels merge recursively
  - Conflicting key types both directions (object replaces primitive; primitive replaces object)
  - `mutate: true` still clones non-plain source values instead of aliasing them
- `src/object/__tests__/deepMerge.fastcheck.ts` (new) — Property-based invariants:
  - Result contains every key from `source` ∪ `target`
  - `mutate = false` mutates neither `source` nor `target`
  - `mutate = true` returns the `target` reference

## Test plan
- [ ] Unit + property suites pass (`npx vitest run src/object/__tests__/deepMerge.*`)
- [ ] Full suite, build, and typecheck pass

## Notes
- Tests only; no production code changes. Generators use proto-safe keys and structured-clone-compatible values for deterministic runs.

Closes #70