### PR TITLE
test: Add missing fast-check property tests

### DIFF
--- a/src/async/__tests__/standby.fastcheck.ts
+++ b/src/async/__tests__/standby.fastcheck.ts
@@ -1,0 +1,23 @@
+import fc from 'fast-check'
+
+import { standby } from '../standby'
+
+describe('standby (property-based)', () => {
+	it('resolves only at or after the given timeout', async () => {
+		await fc.assert(
+			fc.asyncProperty(fc.integer({ min: 1, max: 100000 }), async (timeout) => {
+				vi.useFakeTimers()
+				try {
+					const spy = vi.fn()
+					standby(timeout).then(spy)
+					await vi.advanceTimersByTimeAsync(timeout - 1)
+					expect(spy).not.toHaveBeenCalled()
+					await vi.advanceTimersByTimeAsync(1)
+					expect(spy).toHaveBeenCalledTimes(1)
+				} finally {
+					vi.useRealTimers()
+				}
+			})
+		)
+	})
+})

--- a/src/string/__tests__/interpolate.fastcheck.ts
+++ b/src/string/__tests__/interpolate.fastcheck.ts
@@ -1,0 +1,34 @@
+import fc from 'fast-check'
+
+import { interpolate } from '../interpolate'
+
+const identifier = fc.string({ minLength: 1, maxLength: 6 }).filter((key) => /^\w+$/.test(key))
+const plainValue = fc.string({ maxLength: 8 }).filter((value) => !value.includes('%'))
+
+describe('interpolate (property-based)', () => {
+	it('substitutes every known token with its string value', () => {
+		fc.assert(
+			fc.property(fc.dictionary(identifier, plainValue, { minKeys: 1, maxKeys: 5 }), (tokens) => {
+				const keys = Object.keys(tokens)
+				const value = keys.map((key) => `%${key}%`).join(' ')
+				const result = interpolate(value, tokens)
+				for (const key of keys) {
+					expect(result).not.toContain(`%${key}%`)
+					expect(result).toContain(String(tokens[key]))
+				}
+			})
+		)
+	})
+
+	it('leaves unknown placeholders unchanged', () => {
+		fc.assert(
+			fc.property(
+				identifier.filter((key) => key !== 'known'),
+				(unknownKey) => {
+					const value = `before %${unknownKey}% after`
+					expect(interpolate(value, { known: 'value' })).toBe(value)
+				}
+			)
+		)
+	})
+})

--- a/src/string/__tests__/interpolateLiteral.fastcheck.ts
+++ b/src/string/__tests__/interpolateLiteral.fastcheck.ts
@@ -1,0 +1,30 @@
+import fc from 'fast-check'
+
+import { interpolateLiteral } from '../interpolateLiteral'
+
+const identifier = fc.string({ minLength: 1, maxLength: 6 }).filter((key) => /^\w+$/.test(key))
+const plainValue = fc.string({ maxLength: 8 }).filter((value) => !value.includes('$'))
+
+describe('interpolateLiteral (property-based)', () => {
+	it('replaces every provided token placeholder', () => {
+		fc.assert(
+			fc.property(fc.dictionary(identifier, plainValue, { minKeys: 1, maxKeys: 5 }), (tokens) => {
+				const keys = Object.keys(tokens)
+				const value = keys.map((key) => `\${${key}}`).join(' ')
+				const result = interpolateLiteral(value, tokens)
+				for (const key of keys) {
+					expect(result).not.toContain(`\${${key}}`)
+					expect(result).toContain(String(tokens[key]))
+				}
+			})
+		)
+	})
+
+	it('throws a ReferenceError for a placeholder whose key is absent', () => {
+		fc.assert(
+			fc.property(identifier, (key) => {
+				expect(() => interpolateLiteral(`\${${key}}`, {})).toThrow(ReferenceError)
+			})
+		)
+	})
+})


### PR DESCRIPTION
## Summary
Adds property-based test files for the three utilities that lacked them, asserting meaningful invariants consistent with the rest of the library.

## Changes
- `src/async/__tests__/standby.fastcheck.ts` (new) — With isolated fake timers per run: for an arbitrary timeout, the promise is not resolved after `timeout - 1` ms and is resolved after `timeout` ms.
- `src/string/__tests__/interpolate.fastcheck.ts` (new) — Every known token (non-nil value) is substituted (its `%key%` placeholder disappears, the value appears); unknown placeholders are left unchanged.
- `src/string/__tests__/interpolateLiteral.fastcheck.ts` (new) — Every provided `${key}` placeholder is replaced; an absent key throws `ReferenceError`.

## Test plan
- [ ] The three new property suites pass
- [ ] Full suite, build, and typecheck pass

## Notes
- Tests only; no production code changes.
- Generators use identifier (`\w+`) keys, matching the functions' contract and avoiding the unescaped-regex-metacharacter pitfall in `interpolate` (out of scope here).

Closes #71