### PR TITLE
fix(object): Return false instead of throwing for nullish values in isObject

### DIFF
--- a/src/object/__tests__/deepMerge.test.ts
+++ b/src/object/__tests__/deepMerge.test.ts
@@ -114,6 +114,12 @@ describe('deepMerge', () => {
 			;(result.items as number[]).push(3)
 			expect(items).toEqual([1, 2])
 		})
+
+		it('handles null values without throwing', () => {
+			expect(deepMerge({ a: null }, { a: null })).toEqual({ a: null })
+			expect(deepMerge({ a: null }, { a: { b: 1 } })).toEqual({ a: null })
+			expect(deepMerge({ a: { b: 1 } }, { a: null })).toEqual({ a: { b: 1 } })
+		})
 	})
 
 	describe('merge semantics', () => {

--- a/src/object/__tests__/isObject.test.ts
+++ b/src/object/__tests__/isObject.test.ts
@@ -19,7 +19,9 @@ describe('isObject', function () {
 		/foo/,
 		new Date(),
 		new Error(),
-		Symbol()
+		Symbol(),
+		null,
+		undefined
 	])('returns false', (value) => {
 		expect(isObject(value)).toBeFalsy()
 	})

--- a/src/object/isObject.ts
+++ b/src/object/isObject.ts
@@ -14,4 +14,4 @@
  * @returns `true` whether the value is an object.
  */
 export const isObject = (value: unknown): value is Record<string, unknown> =>
-	Object.getPrototypeOf(value) === Object.prototype
+	value != null && Object.getPrototypeOf(value) === Object.prototype


### PR DESCRIPTION
## Summary
`isObject(null)` and `isObject(undefined)` threw a `TypeError` (via `Object.getPrototypeOf`) instead of returning `false`. As a public exported guard this is incorrect, and it made `deepMerge` throw whenever a key shared between `source` and `target` held a `null` value. This adds a nullish guard.

## Changes
- `src/object/isObject.ts` — Return `false` for `null`/`undefined` (`value != null && Object.getPrototypeOf(value) === Object.prototype`).
- `src/object/__tests__/isObject.test.ts` — Add `null` and `undefined` to the "returns false" cases.
- `src/object/__tests__/deepMerge.test.ts` — Regression: `null` at a shared key (and source-only / target-only) merges without throwing.

## Test plan
- [ ] `isObject(null)` / `isObject(undefined)` return `false` (no throw)
- [ ] `deepMerge({ a: null }, { a: null })` returns `{ a: null }`
- [ ] `deepMerge` property suite passes deterministically (no seed-dependent failures)

## Notes
- This also stabilizes the `deepMerge` property tests added in #70, which intermittently failed by seed because they generate `null` leaves — restoring green `beta` CI and the pre-commit hook.
- Pure correction; no caller can rely on the previous throwing behavior. No breaking change.

Closes #85