### PR TITLE
chore(ci): Update CodeQL workflow actions to current versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,37 +38,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
The CodeQL workflow pinned deprecated action versions (`actions/checkout@v3`, `github/codeql-action/*@v2`). This bumps them to current majors and removes the `autobuild` step, which is unnecessary for a pure JS/TS project (CodeQL analyzes the source directly; autobuild only applies to compiled languages).

## Changes
- `.github/workflows/codeql.yml`:
  - `actions/checkout@v3` → `@v6` (matches `publish.yml`)
  - `github/codeql-action/init@v2` → `@v3`
  - `github/codeql-action/analyze@v2` → `@v3`
  - Remove the `Autobuild` step and its stale template comments

## Test plan
- [ ] CodeQL workflow runs successfully on `main` (it only triggers on push/PR to `main`, so it will validate after beta merges to main)

## Notes
- CI infrastructure only; no library code changes, no breaking changes.
- `language: ['javascript']` kept as-is — still valid in CodeQL Action v3.

Closes #73