### PR TITLE
refactor(string): Simplify pipeTokens with Array.join

### DIFF
--- a/src/string/interpolate.ts
+++ b/src/string/interpolate.ts
@@ -8,10 +8,7 @@ import { isNil } from '../lang/isNil'
 const escapeDivider = (divider: string): string => divider.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 /** @private */
-const pipeTokens = (tokens: Record<string, unknown>): string => {
-	const tokenKeys = Object.keys(tokens)
-	return tokenKeys.reduce((acc, key, i) => `${acc}${i > 0 ? '|' : ''}${key}`, '')
-}
+const pipeTokens = (tokens: Record<string, unknown>): string => Object.keys(tokens).join('|')
 
 /**
  * @function


### PR DESCRIPTION
## Summary
`pipeTokens` built the regex alternation pattern with a manual `reduce`. This replaces it with the equivalent, clearer `Object.keys(tokens).join('|')`.

## Changes
- `src/string/interpolate.ts` — `pipeTokens` now returns `Object.keys(tokens).join('|')`.

## Test plan
- [ ] Existing `interpolate` unit and property tests pass (behavior unchanged)

## Notes
- Internal `@private` helper; no public API change. Strictly equivalent output (`''` for no keys, `key` for one, `a|b|c` for many). No new tests needed — covered by `interpolate.test.ts` and `interpolate.fastcheck.ts`.

Closes #75