### PR TITLE
perf(dom): Avoid array spread in resolveClassName reduce

### DIFF
--- a/src/dom/resolveClassName.ts
+++ b/src/dom/resolveClassName.ts
@@ -31,7 +31,8 @@ export const resolveClassName = (input?: ClassEntry[]): string => {
 			} else {
 				resolved = value
 			}
-			return normalize(resolved) ? [...acc, resolved as string] : acc
+			if (normalize(resolved)) acc.push(resolved as string)
+			return acc
 		}, [])
 		.join(' ')
 }


### PR DESCRIPTION
## Summary
`resolveClassName` rebuilt its accumulator with `[...acc, value]` on every iteration — O(n²) for large inputs. This pushes into the accumulator instead, making it O(n). Order and filtering are unchanged.

## Changes
- `src/dom/resolveClassName.ts` — Replace `return normalize(resolved) ? [...acc, resolved as string] : acc` with `if (normalize(resolved)) acc.push(resolved as string); return acc`.

## Test plan
- [ ] Existing `resolveClassName` unit tests pass (behavior unchanged)

## Notes
- Behavior-preserving internal refactor; no public API or JSDoc change. Covered by the existing `resolveClassName.test.ts` (22 cases).

Closes #76