### PR TITLE
fix(string): Escape token keys when building the interpolate regex

### DIFF
--- a/src/string/__tests__/interpolate.fastcheck.ts
+++ b/src/string/__tests__/interpolate.fastcheck.ts
@@ -2,13 +2,15 @@ import fc from 'fast-check'
 
 import { interpolate } from '../interpolate'
 
-const identifier = fc.string({ minLength: 1, maxLength: 6 }).filter((key) => /^\w+$/.test(key))
+// Keys may contain regex metacharacters; only the divider '%' is excluded.
+const keyChar = fc.constantFrom(...'abAB01.*+?^${}()|[]\\- _'.split(''))
+const tokenKey = fc.array(keyChar, { minLength: 1, maxLength: 6 }).map((chars) => chars.join(''))
 const plainValue = fc.string({ maxLength: 8 }).filter((value) => !value.includes('%'))
 
 describe('interpolate (property-based)', () => {
 	it('substitutes every known token with its string value', () => {
 		fc.assert(
-			fc.property(fc.dictionary(identifier, plainValue, { minKeys: 1, maxKeys: 5 }), (tokens) => {
+			fc.property(fc.dictionary(tokenKey, plainValue, { minKeys: 1, maxKeys: 5 }), (tokens) => {
 				const keys = Object.keys(tokens)
 				const value = keys.map((key) => `%${key}%`).join(' ')
 				const result = interpolate(value, tokens)
@@ -23,7 +25,7 @@ describe('interpolate (property-based)', () => {
 	it('leaves unknown placeholders unchanged', () => {
 		fc.assert(
 			fc.property(
-				identifier.filter((key) => key !== 'known'),
+				tokenKey.filter((key) => key !== 'known'),
 				(unknownKey) => {
 					const value = `before %${unknownKey}% after`
 					expect(interpolate(value, { known: 'value' })).toBe(value)

--- a/src/string/__tests__/interpolate.test.ts
+++ b/src/string/__tests__/interpolate.test.ts
@@ -79,6 +79,28 @@ describe('interpolate', () => {
 		expect(interpolate(value, tokens, divider)).toBe(expected)
 	})
 
+	describe('keys with regex metacharacters', () => {
+		it('matches a key containing "." literally', () => {
+			expect(interpolate('%a.b%', { 'a.b': 'X' })).toBe('X')
+		})
+
+		it('does not over-match a "." key against arbitrary characters', () => {
+			expect(interpolate('%axb%', { 'a.b': 'X' })).toBe('%axb%')
+		})
+
+		it('does not throw and replaces a key containing "("', () => {
+			expect(interpolate('%(%', { '(': 'X' })).toBe('X')
+		})
+
+		it('does not throw and replaces a key containing "["', () => {
+			expect(interpolate('%[%', { '[': 'X' })).toBe('X')
+		})
+
+		it('does not throw and replaces a key containing "\\"', () => {
+			expect(interpolate('%\\%', { '\\': 'X' })).toBe('X')
+		})
+	})
+
 	// prettier-ignore
 	it.each([
 		{

--- a/src/string/interpolate.ts
+++ b/src/string/interpolate.ts
@@ -5,10 +5,10 @@
 import { isNil } from '../lang/isNil'
 
 /** @private */
-const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const escapeDivider = (divider: string): string => divider.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 /** @private */
-const pipeTokens = (tokens: Record<string, unknown>): string => Object.keys(tokens).map(escapeRegExp).join('|')
+const pipeTokens = (tokens: Record<string, unknown>): string => Object.keys(tokens).map(escapeDivider).join('|')
 
 /**
  * @function
@@ -30,7 +30,7 @@ const pipeTokens = (tokens: Record<string, unknown>): string => Object.keys(toke
  * @returns The interpolated string.
  */
 export const interpolate = (value: string, tokens: Record<string, unknown> = {}, divider = '%'): string => {
-	const escapedDivider = escapeRegExp(divider)
+	const escapedDivider = escapeDivider(divider)
 	const pipedTokens = pipeTokens(tokens)
 	const regex = new RegExp(`${escapedDivider}(${pipedTokens})${escapedDivider}`, 'g')
 	return value.replace(regex, (_, r) => (!isNil(tokens[r]) ? String(tokens[r]) : r))

--- a/src/string/interpolate.ts
+++ b/src/string/interpolate.ts
@@ -5,10 +5,10 @@
 import { isNil } from '../lang/isNil'
 
 /** @private */
-const escapeDivider = (divider: string): string => divider.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 /** @private */
-const pipeTokens = (tokens: Record<string, unknown>): string => Object.keys(tokens).join('|')
+const pipeTokens = (tokens: Record<string, unknown>): string => Object.keys(tokens).map(escapeRegExp).join('|')
 
 /**
  * @function
@@ -30,7 +30,7 @@ const pipeTokens = (tokens: Record<string, unknown>): string => Object.keys(toke
  * @returns The interpolated string.
  */
 export const interpolate = (value: string, tokens: Record<string, unknown> = {}, divider = '%'): string => {
-	const escapedDivider = escapeDivider(divider)
+	const escapedDivider = escapeRegExp(divider)
 	const pipedTokens = pipeTokens(tokens)
 	const regex = new RegExp(`${escapedDivider}(${pipedTokens})${escapedDivider}`, 'g')
 	return value.replace(regex, (_, r) => (!isNil(tokens[r]) ? String(tokens[r]) : r))


### PR DESCRIPTION
## Summary
`interpolate` injected token **keys** straight into a `RegExp`, escaping only the divider. Keys containing regex metacharacters either over-matched (e.g. `.` matched any char) or threw a `SyntaxError` (e.g. `(`). This escapes each key with the same routine already applied to the divider.

## Changes
- `src/string/interpolate.ts`:
  - Rename the private `escapeDivider` helper to the generic `escapeRegExp` (now used for both the divider and the keys).
  - `pipeTokens` now escapes each key: `Object.keys(tokens).map(escapeRegExp).join('|')`.
- `src/string/__tests__/interpolate.test.ts` — Regression tests for keys with `.`, `(`, `[`, `\` (exact match, no over-match, no throw).
- `src/string/__tests__/interpolate.fastcheck.ts` — Broaden the key generator to include regex metacharacters (only `%` excluded), proving the escaping is robust.

## Test plan
- [ ] `interpolate('%a.b%', { 'a.b': 'X' })` → `'X'`; `interpolate('%axb%', { 'a.b': 'X' })` → `'%axb%'` (no over-match)
- [ ] `interpolate('%(%', { '(': 'X' })` → `'X'` (no `SyntaxError`)
- [ ] Existing interpolation behavior unchanged (identifier keys need no escaping)

## Notes
- The capture group still yields the *matched* text (the real key), so the `tokens[r]` lookup is unaffected by escaping the pattern.
- Behavior change only for inputs that were previously mishandled (over-matching / throwing) — a correction, not a breaking change for valid usage.

Closes #89