### PR TITLE
fix(string): Return value unchanged when interpolate has no tokens

### DIFF
--- a/src/string/__tests__/interpolate.test.ts
+++ b/src/string/__tests__/interpolate.test.ts
@@ -101,6 +101,24 @@ describe('interpolate', () => {
 		})
 	})
 
+	describe('empty tokens', () => {
+		it('returns value unchanged when tokens contain adjacent dividers', () => {
+			expect(interpolate('100%% done', {})).toBe('100%% done')
+		})
+
+		it('returns value unchanged when tokens is omitted', () => {
+			expect(interpolate('100%% done')).toBe('100%% done')
+		})
+
+		it('does not strip a lone divider when tokens is empty', () => {
+			expect(interpolate('a%b%c', {})).toBe('a%b%c')
+		})
+
+		it('returns value unchanged with a non-default divider', () => {
+			expect(interpolate('100$$ done', {}, '$')).toBe('100$$ done')
+		})
+	})
+
 	// prettier-ignore
 	it.each([
 		{

--- a/src/string/interpolate.ts
+++ b/src/string/interpolate.ts
@@ -32,6 +32,7 @@ const pipeTokens = (tokens: Record<string, unknown>): string => Object.keys(toke
 export const interpolate = (value: string, tokens: Record<string, unknown> = {}, divider = '%'): string => {
 	const escapedDivider = escapeDivider(divider)
 	const pipedTokens = pipeTokens(tokens)
+	// No tokens: use a never-matching regex (not an early return) so value.replace still throws on a non-string value
 	const regex = pipedTokens ? new RegExp(`${escapedDivider}(${pipedTokens})${escapedDivider}`, 'g') : /(?!)/g
 	return value.replace(regex, (_, r) => (!isNil(tokens[r]) ? String(tokens[r]) : r))
 }

--- a/src/string/interpolate.ts
+++ b/src/string/interpolate.ts
@@ -32,6 +32,6 @@ const pipeTokens = (tokens: Record<string, unknown>): string => Object.keys(toke
 export const interpolate = (value: string, tokens: Record<string, unknown> = {}, divider = '%'): string => {
 	const escapedDivider = escapeDivider(divider)
 	const pipedTokens = pipeTokens(tokens)
-	const regex = new RegExp(`${escapedDivider}(${pipedTokens})${escapedDivider}`, 'g')
+	const regex = pipedTokens ? new RegExp(`${escapedDivider}(${pipedTokens})${escapedDivider}`, 'g') : /(?!)/g
 	return value.replace(regex, (_, r) => (!isNil(tokens[r]) ? String(tokens[r]) : r))
 }


### PR DESCRIPTION
## Summary
When `interpolate` is called with an empty `tokens` object, an empty capture group made the regex (`%()%`) match consecutive dividers (e.g. `%%`) and silently strip them. With no tokens, the input string is now returned unchanged.

## Changes
- `src/string/interpolate.ts`: when there are no tokens to interpolate, build a never-matching regex (`/(?!)/g`) instead of one with an empty capture group. `value.replace(...)` and `escapeDivider(divider)` are still invoked, so the existing throw-on-invalid-input behaviour (non-string value/divider, null tokens) is preserved.
- `src/string/__tests__/interpolate.test.ts`: add an `empty tokens` block covering adjacent dividers, omitted tokens, a lone divider, and a non-default divider.

## Test plan
- [x] `yarn test:ci` — 268 tests green, lint clean
- [x] `yarn build`
- [x] `yarn typecheck`
- [x] Existing `throws` tests (non-string value/divider, null tokens) still pass

## Notes
Degenerate edge case (untested, no documented behaviour): `interpolate('%%', { '': 'X' })` now returns `'%%'` instead of `'X'`, since a sole empty-string key also yields an empty `pipedTokens`. This is arguably more correct and affects no documented API.

Closes #93