### PR TITLE
fix(dom): Skip cross-origin stylesheets in getCSSDeclaration

### DIFF
--- a/src/dom/__tests__/getCSSDeclaration.test.ts
+++ b/src/dom/__tests__/getCSSDeclaration.test.ts
@@ -38,4 +38,35 @@ describe('getCSSDeclaration', () => {
 			expect(getCSSDeclaration('drag', true)).toBe('background-color: black;')
 		})
 	})
+
+	describe('With cross-origin stylesheets', () => {
+		const makeCrossOriginSheet = (): CSSStyleSheet =>
+			({
+				get cssRules(): CSSRuleList {
+					throw new DOMException('Cannot access rules', 'SecurityError')
+				},
+			}) as unknown as CSSStyleSheet
+
+		afterEach(() => {
+			vi.restoreAllMocks()
+		})
+
+		it('Skips inaccessible sheets and finds the rule in an accessible one', () => {
+			const merged = [makeCrossOriginSheet(), ...Array.from(document.styleSheets)] as unknown as StyleSheetList
+			vi.spyOn(document, 'styleSheets', 'get').mockReturnValue(merged)
+			expect(getCSSDeclaration('drag', true)).toBe('background-color: black;')
+		})
+
+		it('Returns null when only cross-origin sheets are present', () => {
+			const onlyCrossOrigin = [makeCrossOriginSheet()] as unknown as StyleSheetList
+			vi.spyOn(document, 'styleSheets', 'get').mockReturnValue(onlyCrossOrigin)
+			expect(getCSSDeclaration('drag')).toBeNull()
+		})
+
+		it('Does not throw when iterating cross-origin sheets', () => {
+			const onlyCrossOrigin = [makeCrossOriginSheet()] as unknown as StyleSheetList
+			vi.spyOn(document, 'styleSheets', 'get').mockReturnValue(onlyCrossOrigin)
+			expect(() => getCSSDeclaration('drag')).not.toThrow()
+		})
+	})
 })

--- a/src/dom/__tests__/getCSSDeclaration.test.ts
+++ b/src/dom/__tests__/getCSSDeclaration.test.ts
@@ -52,7 +52,10 @@ describe('getCSSDeclaration', () => {
 		})
 
 		it('Skips inaccessible sheets and finds the rule in an accessible one', () => {
-			const merged = [makeCrossOriginSheet(), ...Array.from(document.styleSheets)] as unknown as StyleSheetList
+			const accessibleSheet = {
+				cssRules: [{ selectorText: '.drag', style: { cssText: 'background-color: black;' } }],
+			} as unknown as CSSStyleSheet
+			const merged = [makeCrossOriginSheet(), accessibleSheet] as unknown as StyleSheetList
 			vi.spyOn(document, 'styleSheets', 'get').mockReturnValue(merged)
 			expect(getCSSDeclaration('drag', true)).toBe('background-color: black;')
 		})

--- a/src/dom/getCSSDeclaration.ts
+++ b/src/dom/getCSSDeclaration.ts
@@ -24,7 +24,14 @@ export const getCSSDeclaration = (className: string, returnText = false): CSSSty
 		className = className.startsWith('.') ? className : `.${className}`
 		if (document.styleSheets?.length) {
 			for (const sheet of document.styleSheets) {
-				for (const rule of sheet.cssRules) {
+				let rules: CSSRuleList
+				try {
+					rules = sheet.cssRules
+				} catch {
+					// Cross-origin stylesheets throw SecurityError on cssRules access
+					continue
+				}
+				for (const rule of rules) {
 					const styleRule = rule as CSSStyleRule
 					if (styleRule.selectorText === className && !!styleRule.style) {
 						return returnText ? styleRule.style.cssText : styleRule.style


### PR DESCRIPTION
## Summary
`getCSSDeclaration` iterated `document.styleSheets` and accessed `sheet.cssRules` unconditionally. Browsers throw a `SecurityError` on `cssRules` for any stylesheet loaded from a different origin, so a single cross-origin `<link>` on the page made the function throw instead of returning the matching declaration or `null`. The fix wraps the `cssRules` access in `try/catch` and skips inaccessible sheets.

## Changes
- `src/dom/getCSSDeclaration.ts`: extract `sheet.cssRules` into a guarded `let rules`; on throw, `continue` to the next sheet. Accessible sheets are processed unchanged.
- `src/dom/__tests__/getCSSDeclaration.test.ts`: add a `With cross-origin stylesheets` block using `vi.spyOn(document, 'styleSheets', 'get')` to inject a sheet whose `cssRules` getter throws `DOMException('...', 'SecurityError')`. Covers three cases: skip-and-find in a later sheet, return `null` when only cross-origin sheets exist, and no-throw guarantee.

## Test plan
- [x] `yarn test:ci` — 271 tests green, lint clean
- [x] `yarn build`
- [x] `yarn typecheck`
- [x] Existing same-origin behaviour unchanged

Closes #94