### PR TITLE
test(async): Use fake timers in debounce tests

### DIFF
--- a/src/async/__tests__/debounce.test.ts
+++ b/src/async/__tests__/debounce.test.ts
@@ -1,72 +1,78 @@
 import { debounce } from '../debounce'
 
-const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
-
 describe('debounce', () => {
-	it('delays invocation until after the delay period', async () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('delays invocation until after the delay period', () => {
 		const fn = vi.fn()
 		const debounced = debounce(fn, 50)
 
 		debounced()
 		expect(fn).not.toHaveBeenCalled()
 
-		await delay(80)
+		vi.advanceTimersByTime(50)
 		expect(fn).toHaveBeenCalledOnce()
 	})
 
-	it('resets the timer on subsequent calls', async () => {
+	it('resets the timer on subsequent calls', () => {
 		const fn = vi.fn()
 		const debounced = debounce(fn, 50)
 
 		debounced()
-		await delay(30)
+		vi.advanceTimersByTime(30)
 		debounced()
-		await delay(30)
+		vi.advanceTimersByTime(30)
 		expect(fn).not.toHaveBeenCalled()
 
-		await delay(40)
+		vi.advanceTimersByTime(20)
 		expect(fn).toHaveBeenCalledOnce()
 	})
 
-	it('passes arguments to the original function', async () => {
+	it('passes arguments to the original function', () => {
 		const fn = vi.fn()
 		const debounced = debounce(fn, 50)
 
 		debounced('hello', 42)
-		await delay(80)
+		vi.advanceTimersByTime(50)
 		expect(fn).toHaveBeenCalledWith('hello', 42)
 	})
 
-	it('uses the arguments from the last call', async () => {
+	it('uses the arguments from the last call', () => {
 		const fn = vi.fn()
 		const debounced = debounce(fn, 50)
 
 		debounced('a')
 		debounced('b')
 		debounced('c')
-		await delay(80)
+		vi.advanceTimersByTime(50)
 		expect(fn).toHaveBeenCalledOnce()
 		expect(fn).toHaveBeenCalledWith('c')
 	})
 
-	it('cancels a pending invocation', async () => {
+	it('cancels a pending invocation', () => {
 		const fn = vi.fn()
 		const debounced = debounce(fn, 50)
 
 		debounced()
 		debounced.cancel()
-		await delay(80)
+		vi.advanceTimersByTime(50)
 		expect(fn).not.toHaveBeenCalled()
 	})
 
-	it('can be called again after cancel', async () => {
+	it('can be called again after cancel', () => {
 		const fn = vi.fn()
 		const debounced = debounce(fn, 50)
 
 		debounced()
 		debounced.cancel()
 		debounced()
-		await delay(80)
+		vi.advanceTimersByTime(50)
 		expect(fn).toHaveBeenCalledOnce()
 	})
 


### PR DESCRIPTION
## Summary
`debounce.test.ts` was the last file in the async suite to depend on real `setTimeout` (via a `delay()` helper) with ~20-30 ms margins against a 50 ms debounce — fragile under loaded CI, as flagged in #78. Convert the suite to `vi.useFakeTimers()` / `vi.advanceTimersByTime()`, mirroring the pattern already used in `throttle.test.ts` and `debounce.fastcheck.ts`.

## Changes
- `src/async/__tests__/debounce.test.ts`: add `beforeEach(vi.useFakeTimers)` / `afterEach(vi.useRealTimers)`; remove the `delay()` helper and all `async`/`await`; replace `await delay(N)` with `vi.advanceTimersByTime(N)`. The "reset on subsequent calls" case advances time in two halves to faithfully reproduce the timer re-scheduling. All 7 cases preserved, no behaviour change.

## Test plan
- [x] `yarn test:ci` — 271 tests green, `debounce.ts` at 100% coverage, lint clean
- [x] `yarn build`
- [x] `yarn typecheck`
- [x] Suite now runs in ~5 ms instead of ~450 ms+ (incidental speedup, but a sign that real timers are gone)

Closes #95