### PR TITLE
chore(ci): Use --frozen-lockfile for yarn install in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: '24'
           cache: 'yarn'
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn typecheck
       - run: yarn test:ci
       - run: yarn build


### PR DESCRIPTION
## Summary
The publish workflow ran `yarn install` without `--frozen-lockfile`, so a `yarn.lock` out of sync with `package.json` would be silently mutated by CI and the release would proceed against a different dependency tree than what's committed. Adding the flag (yarn classic) makes installs reproducible and fails the job fast on lockfile drift.

## Changes
- `.github/workflows/publish.yml`: `yarn install` → `yarn install --frozen-lockfile`.

## Test plan
- [x] Verified locally that `yarn install --frozen-lockfile` succeeds against the current lockfile (no pre-existing drift, so the change won't break the next CI run).
- [ ] Next push to `beta`/`main` will exercise the flag in CI.

Closes #96