### PR TITLE
fix(string): Preserve delimiters in interpolate when token value is nil

### DIFF
--- a/src/dom/__tests__/createElement.test.ts
+++ b/src/dom/__tests__/createElement.test.ts
@@ -120,4 +120,18 @@ describe('createElement', () => {
 		expect(typeof rect.toJSON).toBe('function')
 		expect(rect.toJSON()).toEqual({ x: 5, y: 15, left: 5, top: 15, width: 30, height: 40, right: 35, bottom: 55 })
 	})
+
+	it('defaults x and y to 0 when neither origin nor left/top are provided', () => {
+		const rect = createElement({
+			boundingClientRect: { right: 50, bottom: 30 },
+		}).getBoundingClientRect()
+		expect(rect).toEqual({ x: 0, y: 0, left: 0, top: 0, right: 50, bottom: 30, width: 50, height: 30 })
+	})
+
+	it('defaults width and height to 0 when neither size nor end bounds are provided', () => {
+		const rect = createElement({
+			boundingClientRect: { x: 5, y: 10 },
+		}).getBoundingClientRect()
+		expect(rect).toEqual({ x: 5, y: 10, left: 5, top: 10, right: 5, bottom: 10, width: 0, height: 0 })
+	})
 })

--- a/src/string/__tests__/interpolate.test.ts
+++ b/src/string/__tests__/interpolate.test.ts
@@ -119,6 +119,16 @@ describe('interpolate', () => {
 		})
 	})
 
+	describe('nil token values', () => {
+		it('leaves the token untouched when its value is null', () => {
+			expect(interpolate('%foo%', { foo: null })).toBe('%foo%')
+		})
+
+		it('leaves the token untouched when its value is undefined', () => {
+			expect(interpolate('%foo%', { foo: undefined })).toBe('%foo%')
+		})
+	})
+
 	// prettier-ignore
 	it.each([
 		{

--- a/src/string/interpolate.ts
+++ b/src/string/interpolate.ts
@@ -34,5 +34,5 @@ export const interpolate = (value: string, tokens: Record<string, unknown> = {},
 	const pipedTokens = pipeTokens(tokens)
 	// No tokens: use a never-matching regex (not an early return) so value.replace still throws on a non-string value
 	const regex = pipedTokens ? new RegExp(`${escapedDivider}(${pipedTokens})${escapedDivider}`, 'g') : /(?!)/g
-	return value.replace(regex, (_, r) => (!isNil(tokens[r]) ? String(tokens[r]) : r))
+	return value.replace(regex, (_, r) => (!isNil(tokens[r]) ? String(tokens[r]) : _))
 }


### PR DESCRIPTION
## Summary
Cover the two branches flagged by the coverage report. The `createElement` work is pure test additions, but `interpolate` revealed a latent behavioural inconsistency: a token key present in the alternation but with a `null`/`undefined` value was unwrapped (delimiters stripped) instead of being left untouched. After the fix both modules sit at **100 % branch coverage**.

## Changes
- `src/string/interpolate.ts`: in the replacer, return the full match (`_`) instead of the captured key (`r`) when the token value is nil. Aligns nil-value behaviour with the already-tested missing-key behaviour (both now preserve `%key%`).
- `src/string/__tests__/interpolate.test.ts`: add a `nil token values` block covering both `null` and `undefined`.
- `src/dom/__tests__/createElement.test.ts`: add two cases covering the `boundingClientRect` fallbacks — origin/left/top all undefined (defaults to 0), and size/end-bounds all undefined (width/height default to 0).

## Behaviour change
Per discussion in the issue thread, this is treated as a latent bug rather than a test-only locking. The only observable change:
- Before: `interpolate('%foo%', { foo: null })` → `'foo'`
- After:  `interpolate('%foo%', { foo: null })` → `'%foo%'`

This was not documented anywhere and is inconsistent with the missing-key case. Any consumer relying on the old "unwrap nil tokens" behaviour would need to substitute `null` for the empty string explicitly. No public test covered the old behaviour.

## Test plan
- [x] `yarn test:ci` — 275 tests green, lint clean
- [x] `interpolate.ts` now at **100 %** branch coverage (was 85.71 %)
- [x] `createElement.ts` now at **100 %** branch coverage (was lower)
- [x] `yarn build`
- [x] `yarn typecheck`
- [x] Existing partial-tokens test (`%bar%` left as-is when `bar` not in tokens) still passes — no regression

Closes #98