### PR TITLE
fix(array)!: Return extractByIndices values in indices order

### DIFF
--- a/src/array/__tests__/extractByIndices.fastcheck.ts
+++ b/src/array/__tests__/extractByIndices.fastcheck.ts
@@ -4,7 +4,7 @@ import { extractByIndices } from '../extractByIndices'
 
 describe('extractByIndices', () => {
 	it(
-		'returns only the values located at the given indices',
+		'returns values in the order specified by indices, skipping out-of-bounds entries',
 		() =>
 			fc.assert(
 				fc.property(
@@ -14,13 +14,16 @@ describe('extractByIndices', () => {
 								minLength: length,
 								maxLength: length,
 							}),
-							fc.array(fc.nat({ max: Math.max(length - 1, 0) }), { minLength: length, maxLength: length })
+							fc.array(fc.integer({ min: -length - 5, max: length + 5 }), {
+								minLength: length,
+								maxLength: length,
+							})
 						)
 					}),
 					([source, indices]) => {
 						const target = extractByIndices(source, indices)
-						const indexSet = new Set(indices)
-						expect(target).toEqual(source.filter((_, index) => indexSet.has(index)))
+						const expected = indices.flatMap((i) => (i >= 0 && i < source.length ? [source[i]] : []))
+						expect(target).toEqual(expected)
 					}
 				)
 			),

--- a/src/array/__tests__/extractByIndices.test.ts
+++ b/src/array/__tests__/extractByIndices.test.ts
@@ -38,6 +38,30 @@ describe('extractByIndices', () => {
       source: ['foo', 'bar', 'gag', 'pol', 'zux'],
       indices: [1, 3],
       expected: ['bar', 'pol'],
+    },
+    {
+      name: 'returns values in the order specified by indices',
+      source: ['a', 'b', 'c', 'd'],
+      indices: [3, 1],
+      expected: ['d', 'b'],
+    },
+    {
+      name: 'preserves duplicates in indices',
+      source: ['a', 'b', 'c'],
+      indices: [1, 1, 0],
+      expected: ['b', 'b', 'a'],
+    },
+    {
+      name: 'skips invalid indices while keeping the requested order',
+      source: ['a', 'b', 'c', 'd'],
+      indices: [3, -1, 1, 99],
+      expected: ['d', 'b'],
+    },
+    {
+      name: 'skips non-integer indices',
+      source: ['a', 'b', 'c'],
+      indices: [0, 1.5, 2],
+      expected: ['a', 'c'],
     }
   ])(`$name`, ({source, indices, expected}) => {
     const target = extractByIndices(source, indices)

--- a/src/array/__tests__/extractByIndices.test.ts
+++ b/src/array/__tests__/extractByIndices.test.ts
@@ -41,27 +41,27 @@ describe('extractByIndices', () => {
     },
     {
       name: 'returns values in the order specified by indices',
-      source: ['a', 'b', 'c', 'd'],
+      source: ['foo', 'bar', 'gag', 'pol', 'zux'],
       indices: [3, 1],
-      expected: ['d', 'b'],
+      expected: ['pol', 'bar'],
     },
     {
       name: 'preserves duplicates in indices',
-      source: ['a', 'b', 'c'],
+      source: ['foo', 'bar', 'gag', 'pol', 'zux'],
       indices: [1, 1, 0],
-      expected: ['b', 'b', 'a'],
+      expected: ['bar', 'bar', 'foo'],
     },
     {
       name: 'skips invalid indices while keeping the requested order',
-      source: ['a', 'b', 'c', 'd'],
+      source: ['foo', 'bar', 'gag', 'pol', 'zux'],
       indices: [3, -1, 1, 99],
-      expected: ['d', 'b'],
+      expected: ['pol', 'bar'],
     },
     {
       name: 'skips non-integer indices',
-      source: ['a', 'b', 'c'],
+      source: ['foo', 'bar', 'gag', 'pol', 'zux'],
       indices: [0, 1.5, 2],
-      expected: ['a', 'c'],
+      expected: ['foo', 'gag'],
     }
   ])(`$name`, ({source, indices, expected}) => {
     const target = extractByIndices(source, indices)

--- a/src/array/extractByIndices.ts
+++ b/src/array/extractByIndices.ts
@@ -8,12 +8,23 @@
  * import { extractByIndices } from '@untemps/utils/array/extractByIndices'
  *
  * const source = ['foo', 'bar', 'gag', 'pol', 'zux']
- * const indices = [1, 3]
- * extractByIndices(source, indices) // ['bar', 'pol']
+ * const indices = [3, 1]
+ * extractByIndices(source, indices) // ['pol', 'bar']
  *
  * @param source    - The source array from which extract the values.
- * @param indices   - An array of indices.
- * @returns A new array containing the values at the specified indices only.
+ * @param indices   - An array of indices. The result preserves this order and duplicates.
+ *                    Out-of-bounds, negative, and non-integer indices are silently skipped.
+ * @returns A new array containing the values at the specified indices, in the order of `indices`.
  */
-export const extractByIndices = <T>(source?: T[], indices?: number[]): T[] =>
-	source?.filter((_, i) => indices?.includes(i)) ?? []
+export const extractByIndices = <T>(source?: T[], indices?: number[]): T[] => {
+	if (!source || !indices) return []
+	const { length } = source
+	const result: T[] = []
+	for (let i = 0; i < indices.length; i++) {
+		const index = indices[i]
+		if (index >= 0 && index < length && Number.isInteger(index)) {
+			result.push(source[index])
+		}
+	}
+	return result
+}


### PR DESCRIPTION
## Summary
Reimplements `extractByIndices` so the returned array mirrors the order of the `indices` argument instead of the source array. Duplicates in `indices` are preserved; out-of-bounds, negative, and non-integer entries are silently skipped.

## Changes
- `src/array/extractByIndices.ts`: replace `source.filter` with a single-pass loop over `indices`, pushing `source[i]` when `i` is a valid integer index.
- JSDoc updated with a non-sorted example and explicit notes on order, duplicates, and skipped entries.
- Unit tests cover indices order, duplicate indices, mixed valid/invalid indices, and non-integer indices.
- Fast-check oracle adapted to `indices.flatMap(i => valid ? [source[i]] : [])` and the generator widened to also produce out-of-bounds/negative indices.

## ⚠️ Breaking changes
- **`extractByIndices` result order** now follows the `indices` array. Callers relying on source-order output must sort `indices` upstream (`extractByIndices(src, [...indices].sort((a, b) => a - b))`).
- Targeting `beta` because this changes observable behaviour of a public API.

## Test plan
- [x] `yarn test:ci` (vitest + coverage + eslint) — 280 tests passing
- [x] `yarn build` — clean
- [x] `yarn typecheck` — clean
- [ ] Verify on `beta` that downstream consumers see the new order

Closes #109