### PR TITLE
fix(dom)!: Throw ReferenceError when modifyElement selector matches nothing

### DIFF
--- a/src/dom/__tests__/modifyElement.test.ts
+++ b/src/dom/__tests__/modifyElement.test.ts
@@ -84,4 +84,11 @@ describe('modifyElement', () => {
 	])('$name', ({ getElement, attributes }) => {
 		expect(() => modifyElement(getElement(), attributes as unknown as Record<string, string>)).toThrow()
 	})
+
+	it('throws ReferenceError when string selector does not match any element', () => {
+		expect(() => modifyElement('#does-not-exist', { class: 'bar' })).toThrow(ReferenceError)
+		expect(() => modifyElement('#does-not-exist', { class: 'bar' })).toThrow(
+			"Selector '#does-not-exist' did not match any element"
+		)
+	})
 })

--- a/src/dom/modifyElement.ts
+++ b/src/dom/modifyElement.ts
@@ -14,16 +14,24 @@ import { isString } from '../string/isString'
  * document.body.appendChild(element)
  *
  * modifyElement(element, { className: 'bar' }) // <div class="bar"></div>
+ * modifyElement('#missing', { className: 'bar' }) // throws ReferenceError
  *
  * @param element    - The DOM element or selector of the DOM element to modify.
  * @param attributes - The new attributes to set to the DOM element.
+ * @throws {ReferenceError} When `element` is a string selector that does not match any element in the document.
  * @returns The modified DOM element.
  */
 export const modifyElement = (
 	element: HTMLElement | string,
 	attributes: Record<string, string | null | undefined> = {}
 ): HTMLElement | null => {
-	const el: HTMLElement | null = isString(element) ? document.querySelector<HTMLElement>(element) : element
+	let el: HTMLElement | null
+	if (isString(element)) {
+		el = document.querySelector<HTMLElement>(element)
+		if (el === null) throw new ReferenceError(`Selector '${element}' did not match any element`)
+	} else {
+		el = element
+	}
 	for (const [key, value] of Object.entries(attributes)) {
 		if (value === undefined || value === null) {
 			el?.removeAttribute(key)


### PR DESCRIPTION
## Summary
`modifyElement` previously silently no-oped when called with a string selector that did not match any element in the document, returning `null` with no signal of failure. It now throws a `ReferenceError` naming the offending selector, mirroring the rigour of `interpolateLiteral`'s missing-token throw.

## Changes
- `src/dom/modifyElement.ts`: after resolving a string selector via `document.querySelector`, throw `ReferenceError("Selector '<selector>' did not match any element")` when the result is `null`. Existing behaviour for non-string `element` arguments is preserved.
- JSDoc updated with `@throws {ReferenceError}` and an example illustrating the throw.
- Unit test added covering both the error type and the message.

## ⚠️ Breaking changes
- **`modifyElement(selector, attrs)`** now throws `ReferenceError` when `selector` resolves to nothing. Callers that relied on the silent `null` return must either catch the error or pre-check with `document.querySelector` before calling `modifyElement`.
- Calls that pass an `HTMLElement | null | undefined` reference directly are unchanged (still a no-op returning the input).
- Targeting `beta` because this changes observable behaviour of a public API.

## Test plan
- [x] `yarn test:ci` (vitest + coverage + eslint) — 281 tests passing
- [x] `yarn build` — clean
- [x] `yarn typecheck` — clean

Closes #110