### PR TITLE
chore(dom)!: Use Element.remove() in removeElement

### DIFF
--- a/src/dom/__tests__/removeElement.test.ts
+++ b/src/dom/__tests__/removeElement.test.ts
@@ -34,14 +34,15 @@ describe('removeElement', () => {
 			element: null,
 		},
 		{
-			name: 'returns undefined if element does not exist',
-			element: document.createElement('div'),
-		},
-		{
 			name: 'returns undefined if element selector does not match existing element',
 			element: '.bar',
 		},
 	])('$name', ({ element }) => {
 		expect(removeElement(element as unknown as HTMLElement)).toBeUndefined()
+	})
+
+	it('returns the element unchanged when it has no parent', () => {
+		const detached = document.createElement('div')
+		expect(removeElement(detached)).toBe(detached)
 	})
 })

--- a/src/dom/removeElement.ts
+++ b/src/dom/removeElement.ts
@@ -16,9 +16,11 @@ import { isString } from '../string/isString'
  * removeElement(element) // returns the detached <div class="foo"></div>
  *
  * @param element  - The DOM element or the selector of the DOM element to remove.
- * @returns The removed DOM element.
+ * @returns The removed DOM element, or `undefined` when the input is `null`/`undefined` or the
+ *          selector matches nothing. An element with no parent is returned unchanged.
  */
 export const removeElement = (element: HTMLElement | string): HTMLElement | undefined => {
 	const el: HTMLElement | null = isString(element) ? document.querySelector<HTMLElement>(element) : element
-	return el?.parentNode?.removeChild(el) as HTMLElement | undefined
+	el?.remove()
+	return el ?? undefined
 }


### PR DESCRIPTION
## Summary
Modernises `removeElement` by replacing the legacy `parentNode.removeChild(el)` call with the `Element.remove()` mixin. Drops the explicit cast on the return value because the variable's own type already matches the function signature.

## Changes
- `src/dom/removeElement.ts`: switch to `el?.remove(); return el ?? undefined`. JSDoc clarifies what is returned in edge cases (null/undefined input, non-matching selector, detached element).
- `src/dom/__tests__/removeElement.test.ts`: pull the detached-element case out of the "returns undefined" table and assert the element is returned unchanged.

## ⚠️ Breaking changes
- **`removeElement(detached)`** previously returned `undefined` because `parentNode` was `null`. It now returns the detached element unchanged, because `Element.remove()` is a no-op on a detached node and the returned value comes straight from the resolved variable.
- Migration: callers that distinguished "nothing to remove" from "element removed" via the `undefined` return must instead check `el.parentNode` upstream of the call.
- Targeting `beta` because this changes observable behaviour of a public API.

## Test plan
- [x] `yarn test:ci` (vitest + coverage + eslint) — 281 tests passing
- [x] `yarn build` — clean
- [x] `yarn typecheck` — clean

Closes #111