### PR TITLE
chore(ci): Run CodeQL on the beta branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "beta" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "main", "beta" ]
   schedule:
     - cron: '28 12 * * 3'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "beta" ]
+    branches:
+      - main
+      - beta
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main", "beta" ]
+    branches:
+      - main
+      - beta
   schedule:
     - cron: '28 12 * * 3'
 


### PR DESCRIPTION
## Summary
Extends the CodeQL workflow triggers to include the `beta` branch, so the 4.0 development line gets scanned alongside `main`.

## Changes
- `.github/workflows/codeql.yml`: add `"beta"` to both `push.branches` and `pull_request.branches`. No other configuration changes — the schedule, permissions, language matrix and steps remain identical.

## Propagation note
GitHub evaluates the `pull_request.branches` filter against the workflow file present on the base branch when the PR is opened. This PR itself targets `beta`, but the workflow file on `beta` still lists only `main`, so CodeQL **will not run on this PR**. From the next push/PR onto `beta` after this PR is merged, the new triggers apply.

## Test plan
- [x] `yarn test:ci` — 281 tests passing (sanity, no source change)
- [x] `yarn build` — clean
- [x] `yarn typecheck` — clean
- [ ] After merge: confirm the next PR targeting `beta` triggers the CodeQL workflow

Closes #112