### PR TITLE
chore(ci): Enforce coverage thresholds in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-vitest run && yarn prettier && yarn lint && yarn typecheck
+yarn test:ci && yarn prettier && yarn typecheck


### PR DESCRIPTION
## Summary
Replaces `vitest run` with `yarn test:ci` in `.husky/pre-commit` so the v8 coverage thresholds defined in `vite.config.ts` (statements 95, branches 90, functions 95, lines 95) are evaluated locally before a commit lands — instead of only on push to `main`/`beta` via `publish.yml`, which is too late to block a regression. Drops the now-redundant `yarn lint` since `test:ci` already runs it.

## Changes
- `.husky/pre-commit`: from `vitest run && yarn prettier && yarn lint && yarn typecheck` to `yarn test:ci && yarn prettier && yarn typecheck`.

## Trade-off
Pre-commit gains a few seconds for the coverage report. Acceptable for a library of this size, and matches what the CI publish workflow already runs. The new hook was exercised by this very commit and produced a green pipeline with 100% coverage on all files.

## Test plan
- [x] `yarn test:ci` — 281 tests passing, 100% coverage across all metrics (well above thresholds)
- [x] `yarn prettier` — no changes
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [x] Hook self-validated on the very commit that updates it (git reads `.husky/pre-commit` at invocation time)

Closes #113