### PR TITLE
docs(object): Document deepClone DataCloneError throw and deepMerge divergence

### DIFF
--- a/src/object/deepClone.ts
+++ b/src/object/deepClone.ts
@@ -12,7 +12,12 @@
  * clone.b.c.push(4)
  * console.log(original.b.c) // [2, 3]
  *
+ * Strict by design: non-cloneable values (functions, DOM nodes, non-serialisable instances)
+ * throw `DataCloneError`. If you need lenient behaviour that falls back to a by-reference
+ * copy for such values, use `deepMerge` instead.
+ *
  * @param value - The value to deep clone. Must be serialisable by the structured clone algorithm (functions and DOM nodes are not supported).
+ * @throws {DataCloneError} When `value` contains a non-serialisable entry — for example a function, a DOM node, or an instance the structured clone algorithm cannot handle.
  * @returns A deep clone of the value.
  */
 export const deepClone = <T>(value: T): T => structuredClone(value)


### PR DESCRIPTION
## Summary
Enriches the JSDoc of `deepClone` to make two things explicit: it throws `DataCloneError` when the input is not serialisable, and it diverges intentionally from `deepMerge` (which since #99 falls back to a by-reference copy for non-cloneable values).

## Changes
- `src/object/deepClone.ts`: add a paragraph describing the strict-by-design behaviour and the divergence from `deepMerge`, plus a `@throws {DataCloneError}` tag for IDE and TypeDoc consumers.

## Test plan
- [x] `yarn test:ci` — 281 tests passing, 100% coverage (sanity, no source-code change)
- [x] `yarn build` — clean
- [x] `yarn typecheck` — clean
- [ ] TypeDoc regeneration on the next `yarn docs` will surface the new prose and `@throws` in the API page

Closes #115