### PR TITLE
feat(string)!: Harmonize missing-key behaviour between interpolate and interpolateLiteral

### DIFF
--- a/src/string/__tests__/interpolateLiteral.fastcheck.ts
+++ b/src/string/__tests__/interpolateLiteral.fastcheck.ts
@@ -20,10 +20,10 @@ describe('interpolateLiteral (property-based)', () => {
 		)
 	})
 
-	it('throws a ReferenceError for a placeholder whose key is absent', () => {
+	it('preserves the placeholder when a key is absent', () => {
 		fc.assert(
 			fc.property(identifier, (key) => {
-				expect(() => interpolateLiteral(`\${${key}}`, {})).toThrow(ReferenceError)
+				expect(interpolateLiteral(`\${${key}}`, {})).toBe(`\${${key}}`)
 			})
 		)
 	})

--- a/src/string/__tests__/interpolateLiteral.test.ts
+++ b/src/string/__tests__/interpolateLiteral.test.ts
@@ -57,4 +57,8 @@ describe('interpolateLiteral', () => {
 	it('preserves the placeholder when tokens is omitted and a token is present', () => {
 		expect(interpolateLiteral('A ${foo}')).toBe('A ${foo}')
 	})
+
+	it('distinguishes missing keys (preserved) from present nil values (coerced)', () => {
+		expect(interpolateLiteral('${foo} ${bar}', { bar: null })).toBe('${foo} null')
+	})
 })

--- a/src/string/__tests__/interpolateLiteral.test.ts
+++ b/src/string/__tests__/interpolateLiteral.test.ts
@@ -49,9 +49,9 @@ describe('interpolateLiteral', () => {
 	})
 
 	it('preserves the placeholder when a key is missing', () => {
-		expect(interpolateLiteral('A ${foo} with fun "${bar}" and a lot of ${fun}', { foo: 'bird', fun: 'dignity' })).toBe(
-			'A bird with fun "${bar}" and a lot of dignity'
-		)
+		expect(
+			interpolateLiteral('A ${foo} with fun "${bar}" and a lot of ${fun}', { foo: 'bird', fun: 'dignity' })
+		).toBe('A bird with fun "${bar}" and a lot of dignity')
 	})
 
 	it('preserves the placeholder when tokens is omitted and a token is present', () => {

--- a/src/string/__tests__/interpolateLiteral.test.ts
+++ b/src/string/__tests__/interpolateLiteral.test.ts
@@ -40,15 +40,6 @@ describe('interpolateLiteral', () => {
 			},
 			error: TypeError
 		},
-		{
-			name: 'throws if one token is missing',
-			value: 'A ${foo} with fun "${bar}" and a lot of ${fun}',
-			tokens: {
-				foo: 'bird',
-				fun: 'dignity',
-			},
-			error: 'bar is not defined'
-		}
 	])('$name', ({value, tokens, error}) => {
 		expect(() => interpolateLiteral(value as unknown as string, tokens as unknown as Record<string, unknown>)).toThrow(error)
 	})
@@ -57,8 +48,13 @@ describe('interpolateLiteral', () => {
 		expect(interpolateLiteral('A plain string with no token')).toBe('A plain string with no token')
 	})
 
-	it('throws a ReferenceError (not a TypeError) when tokens is omitted and a token is present', () => {
-		expect(() => interpolateLiteral('A ${foo}')).toThrow(ReferenceError)
-		expect(() => interpolateLiteral('A ${foo}')).toThrow('foo is not defined')
+	it('preserves the placeholder when a key is missing', () => {
+		expect(interpolateLiteral('A ${foo} with fun "${bar}" and a lot of ${fun}', { foo: 'bird', fun: 'dignity' })).toBe(
+			'A bird with fun "${bar}" and a lot of dignity'
+		)
+	})
+
+	it('preserves the placeholder when tokens is omitted and a token is present', () => {
+		expect(interpolateLiteral('A ${foo}')).toBe('A ${foo}')
 	})
 })

--- a/src/string/interpolateLiteral.ts
+++ b/src/string/interpolateLiteral.ts
@@ -15,13 +15,17 @@
  * }
  * interpolateLiteral(value, tokens) // A bird with 3 "wings" and a lot of dignity
  *
+ * Tokens whose key is absent from `tokens` are left untouched in the output, mirroring the
+ * lenient behaviour of `interpolate`. Values that are present (including `null`, `undefined`,
+ * symbols) are coerced via `String(value)`.
+ *
  * @param value   - The literal-like string value to interpolate.
  * @param tokens  - An object of key/value pairs to replace the tokens. Keys must be valid identifiers (`\w+`). Defaults to `{}`.
  * @returns The interpolated string.
  */
 export const interpolateLiteral = (value: string, tokens: Record<string, unknown> = {}): string => {
-	return value.replace(/\$\{(\w+)\}/g, (_, key) => {
-		if (!Object.hasOwn(tokens, key)) throw new ReferenceError(`${key} is not defined`)
+	return value.replace(/\$\{(\w+)\}/g, (match, key) => {
+		if (!Object.hasOwn(tokens, key)) return match
 		return String(tokens[key])
 	})
 }


### PR DESCRIPTION
## Summary
Aligns `interpolateLiteral` with `interpolate`'s lenient handling of **missing keys**: a placeholder whose key is absent from `tokens` is now preserved in the output instead of throwing a `ReferenceError`. The two interpolators are now aligned on the missing-key path; the nil-value path still diverges intentionally (see "Scope" below).

## Changes
- `src/string/interpolateLiteral.ts`: replace `throw new ReferenceError(...)` with `return match` (the original placeholder) when the key is absent. JSDoc updated to explicitly describe the lenient missing-key contract and the parallel with `interpolate`, while clarifying that present nil values are coerced via `String(value)`.
- `src/string/__tests__/interpolateLiteral.test.ts`: drop the two `throws … is not defined` cases and add their lenient equivalents — `preserves the placeholder when a key is missing` and `preserves the placeholder when tokens is omitted and a token is present`. Added a boundary test `distinguishes missing keys (preserved) from present nil values (coerced)` to pin the asymmetry intentionally.
- `src/string/__tests__/interpolateLiteral.fastcheck.ts`: invert the property from "throws on absent key" to "preserves the placeholder on absent key".

## Scope
This PR harmonizes **missing-key handling only**. Nil-value handling still differs between the two utilities:

| Scenario | `interpolate` | `interpolateLiteral` |
| --- | --- | --- |
| `{ foo: 'x' }` → `foo` | replace | replace |
| `{}` → `foo` | preserve | **preserve** (changed) |
| `{ foo: null }` | preserve (via `!isNil`) | coerce to `'null'` |
| `{ foo: undefined }` | preserve (via `!isNil`) | coerce to `'undefined'` |

A follow-up issue could decide whether to converge nil-value handling too (either direction is itself a breaking change of one of the two functions).

## ⚠️ Breaking changes
- **`interpolateLiteral`** no longer throws `ReferenceError` when a placeholder key is missing from `tokens`. The placeholder is preserved in the result.
- Migration: callers that relied on the throw to detect typos must pre-validate the keys before calling — e.g. `for (const [, key] of value.matchAll(/\$\{(\w+)\}/g)) if (!(key in tokens)) throw new ReferenceError(...)`.
- Targeting `beta` because this changes observable behaviour of a public API.

## Test plan
- [x] `yarn test:ci` — 282 tests passing, 100% coverage on all metrics
- [x] `yarn build` — clean
- [x] `yarn typecheck` — clean

Closes #116
