### PR TITLE
fix(string)!: Harmonize nil-value handling between interpolate and interpolateLiteral

### DIFF
--- a/src/string/__tests__/interpolateLiteral.test.ts
+++ b/src/string/__tests__/interpolateLiteral.test.ts
@@ -21,11 +21,16 @@ describe('interpolateLiteral', () => {
 
 	// prettier-ignore
 	it.each([
-		{ bar: null,           expected: 'null'        },
-		{ bar: undefined,      expected: 'undefined'   },
-		{ bar: Symbol('sym'),  expected: 'Symbol(sym)' },
-	])('coerces token value to string: $expected', ({ bar, expected }) => {
+		{ bar: null,      expected: '${bar}' },
+		{ bar: undefined, expected: '${bar}' },
+	])('preserves the placeholder when the token value is $bar', ({ bar, expected }) => {
 		expect(interpolateLiteral('A ${foo} and ${bar}', { foo: 'bird', bar } as Record<string, unknown>)).toBe(`A bird and ${expected}`)
+	})
+
+	it('coerces non-nil token values to string (including symbols)', () => {
+		expect(interpolateLiteral('A ${foo} and ${bar}', { foo: 'bird', bar: Symbol('sym') })).toBe(
+			'A bird and Symbol(sym)'
+		)
 	})
 
 	// prettier-ignore
@@ -58,7 +63,7 @@ describe('interpolateLiteral', () => {
 		expect(interpolateLiteral('A ${foo}')).toBe('A ${foo}')
 	})
 
-	it('distinguishes missing keys (preserved) from present nil values (coerced)', () => {
-		expect(interpolateLiteral('${foo} ${bar}', { bar: null })).toBe('${foo} null')
+	it('preserves the placeholder for both missing keys and present nil values', () => {
+		expect(interpolateLiteral('${foo} ${bar} ${baz}', { bar: null, baz: undefined })).toBe('${foo} ${bar} ${baz}')
 	})
 })

--- a/src/string/__tests__/interpolateLiteral.test.ts
+++ b/src/string/__tests__/interpolateLiteral.test.ts
@@ -1,3 +1,4 @@
+import { interpolate } from '../interpolate'
 import { interpolateLiteral } from '../interpolateLiteral'
 
 describe('interpolateLiteral', () => {
@@ -65,5 +66,19 @@ describe('interpolateLiteral', () => {
 
 	it('preserves the placeholder for both missing keys and present nil values', () => {
 		expect(interpolateLiteral('${foo} ${bar} ${baz}', { bar: null, baz: undefined })).toBe('${foo} ${bar} ${baz}')
+	})
+
+	describe('parity with interpolate', () => {
+		// prettier-ignore
+		it.each([
+			{ name: 'full tokens',                tokens: { foo: 'bird', bar: 'wings' }, expectLiteral: 'bird wings',     expectPercent: 'bird wings'     },
+			{ name: 'partial tokens (missing)',   tokens: { foo: 'bird' },               expectLiteral: 'bird ${bar}',    expectPercent: 'bird %bar%'     },
+			{ name: 'nil value (null)',           tokens: { foo: 'bird', bar: null },    expectLiteral: 'bird ${bar}',    expectPercent: 'bird %bar%'     },
+			{ name: 'nil value (undefined)',      tokens: { foo: 'bird', bar: undefined }, expectLiteral: 'bird ${bar}',  expectPercent: 'bird %bar%'     },
+			{ name: 'no tokens at all',           tokens: {},                            expectLiteral: '${foo} ${bar}',  expectPercent: '%foo% %bar%'    },
+		])('treats $name identically across both functions', ({ tokens, expectLiteral, expectPercent }) => {
+			expect(interpolateLiteral('${foo} ${bar}', tokens as Record<string, unknown>)).toBe(expectLiteral)
+			expect(interpolate('%foo% %bar%', tokens as Record<string, unknown>)).toBe(expectPercent)
+		})
 	})
 })

--- a/src/string/interpolateLiteral.ts
+++ b/src/string/interpolateLiteral.ts
@@ -2,6 +2,8 @@
  * @module string/interpolateLiteral
  */
 
+import { isNil } from '../lang/isNil'
+
 /**
  * @function
  * @example
@@ -15,9 +17,9 @@
  * }
  * interpolateLiteral(value, tokens) // A bird with 3 "wings" and a lot of dignity
  *
- * Tokens whose key is absent from `tokens` are left untouched in the output, mirroring the
- * lenient behaviour of `interpolate`. Values that are present (including `null`, `undefined`,
- * symbols) are coerced via `String(value)`.
+ * Placeholders are preserved when the corresponding key is missing from `tokens` or when its
+ * value is `null` / `undefined`, mirroring the behaviour of `interpolate`. Other values
+ * (including symbols) are coerced via `String(value)`.
  *
  * @param value   - The literal-like string value to interpolate.
  * @param tokens  - An object of key/value pairs to replace the tokens. Keys must be valid identifiers (`\w+`). Defaults to `{}`.
@@ -25,7 +27,7 @@
  */
 export const interpolateLiteral = (value: string, tokens: Record<string, unknown> = {}): string => {
 	return value.replace(/\$\{(\w+)\}/g, (match, key) => {
-		if (!Object.hasOwn(tokens, key)) return match
+		if (!Object.hasOwn(tokens, key) || isNil(tokens[key])) return match
 		return String(tokens[key])
 	})
 }


### PR DESCRIPTION
## Summary
Aligns `interpolateLiteral` with `interpolate` on nil token values. After #124 fixed missing-key parity, the two utilities still diverged on explicit `null` / `undefined`: `interpolate` preserved the placeholder while `interpolateLiteral` coerced to the literal strings `"null"` / `"undefined"`. Both now follow a single rule — placeholder preserved when the value is nil.

## Changes
- `interpolateLiteral` now returns the original placeholder when `tokens[key]` is `null` or `undefined`.
- JSDoc updated to describe the new contract (nil = preserved, non-nil including symbols = coerced via `String(value)`).
- Test suite updated to assert the new behavior, plus a `parity with interpolate` describe block that locks the shared contract across both functions (full / partial / nil / empty tokens).

## ⚠️ Breaking changes
- **`interpolateLiteral`**: passing `{ foo: null }` or `{ foo: undefined }` no longer produces the strings `"null"` / `"undefined"`. The placeholder (e.g. `${foo}`) is preserved instead.
- **Migration**: callers that relied on the literal stringification of nil values must coerce explicitly before calling `interpolateLiteral`, e.g. `{ foo: String(maybeNil) }`.

## Test plan
- [x] `yarn test:ci` — 287 tests pass, 100% coverage, lint clean
- [x] `yarn build` — Vite + tsc declarations succeed
- [x] `yarn typecheck` — no errors
- [x] Parity describe block exercises both functions on the same scenarios

Closes #125