### PR TITLE
fix(dom)!: Harmonize missing-target behaviour between removeElement and modifyElement

### DIFF
--- a/src/dom/__tests__/removeElement.test.ts
+++ b/src/dom/__tests__/removeElement.test.ts
@@ -1,4 +1,5 @@
 import { createElement } from '../createElement'
+import { modifyElement } from '../modifyElement'
 import { removeElement } from '../removeElement'
 
 describe('removeElement', () => {
@@ -39,5 +40,16 @@ describe('removeElement', () => {
 	it('throws ReferenceError when string selector does not match any element', () => {
 		expect(() => removeElement('#does-not-exist')).toThrow(ReferenceError)
 		expect(() => removeElement('#does-not-exist')).toThrow("Selector '#does-not-exist' did not match any element")
+	})
+
+	describe('parity with modifyElement', () => {
+		// prettier-ignore
+		it.each([
+			{ name: 'removeElement', fn: () => removeElement('#does-not-exist') },
+			{ name: 'modifyElement', fn: () => modifyElement('#does-not-exist', { class: 'bar' }) },
+		])('$name throws ReferenceError with the same message on a missing selector', ({ fn }) => {
+			expect(fn).toThrow(ReferenceError)
+			expect(fn).toThrow("Selector '#does-not-exist' did not match any element")
+		})
 	})
 })

--- a/src/dom/__tests__/removeElement.test.ts
+++ b/src/dom/__tests__/removeElement.test.ts
@@ -27,22 +27,17 @@ describe('removeElement', () => {
 		expect(removeElement(getElement())).not.toBeInTheDocument()
 	})
 
-	// prettier-ignore
-	it.each([
-		{
-			name: 'returns undefined if element is null',
-			element: null,
-		},
-		{
-			name: 'returns undefined if element selector does not match existing element',
-			element: '.bar',
-		},
-	])('$name', ({ element }) => {
-		expect(removeElement(element as unknown as HTMLElement)).toBeUndefined()
+	it('returns undefined if element is null', () => {
+		expect(removeElement(null as unknown as HTMLElement)).toBeUndefined()
 	})
 
 	it('returns the element unchanged when it has no parent', () => {
 		const detached = document.createElement('div')
 		expect(removeElement(detached)).toBe(detached)
+	})
+
+	it('throws ReferenceError when string selector does not match any element', () => {
+		expect(() => removeElement('#does-not-exist')).toThrow(ReferenceError)
+		expect(() => removeElement('#does-not-exist')).toThrow("Selector '#does-not-exist' did not match any element")
 	})
 })

--- a/src/dom/removeElement.ts
+++ b/src/dom/removeElement.ts
@@ -14,13 +14,21 @@ import { isString } from '../string/isString'
  * document.body.appendChild(element)
  *
  * removeElement(element) // returns the detached <div class="foo"></div>
+ * removeElement('#missing') // throws ReferenceError
  *
  * @param element  - The DOM element or the selector of the DOM element to remove.
- * @returns The removed DOM element, or `undefined` when the input is `null`/`undefined` or the
- *          selector matches nothing. An element with no parent is returned unchanged.
+ * @throws {ReferenceError} When `element` is a string selector that does not match any element in the document.
+ * @returns The removed DOM element, or `undefined` when the input is `null`/`undefined`. An
+ *          element with no parent is returned unchanged.
  */
 export const removeElement = (element: HTMLElement | string): HTMLElement | undefined => {
-	const el: HTMLElement | null = isString(element) ? document.querySelector<HTMLElement>(element) : element
+	let el: HTMLElement | null
+	if (isString(element)) {
+		el = document.querySelector<HTMLElement>(element)
+		if (el === null) throw new ReferenceError(`Selector '${element}' did not match any element`)
+	} else {
+		el = element
+	}
 	el?.remove()
 	return el ?? undefined
 }


### PR DESCRIPTION
## Summary
Aligns `removeElement` with the decision already taken for `modifyElement` in #119: a string selector that matches no element in the document now throws a `ReferenceError` instead of silently returning `undefined`. The two sibling DOM mutators now share the same missing-target contract, removing a long-standing API inconsistency.

## Changes
- `removeElement` throws `ReferenceError("Selector '<sel>' did not match any element")` when the string input does not resolve to a DOM node. The wording matches `modifyElement` byte-for-byte.
- JSDoc updated with `@throws {ReferenceError}` and an example call.
- Tests reshuffled: removed the obsolete `it.each` row that asserted `undefined` on a missing selector, added a dedicated `throws ReferenceError when string selector does not match any element` case mirroring `modifyElement.test.ts:88-93`.
- Other contract branches are unchanged: `null`/`undefined` input still returns `undefined`, an `HTMLElement` with no parent is still returned unchanged.

## ⚠️ Breaking changes
- **`removeElement(selector)`**: a string selector that matches no element used to return `undefined`. It now throws `ReferenceError` with the same message format as `modifyElement`.
- **Migration**: callers relying on `removeElement('#missing')` returning `undefined` must either guard with a `document.querySelector` check first, wrap the call in `try/catch`, or pass the resolved element instead of the selector.

## Test plan
- [x] `yarn test:ci` — 287 tests pass, 100% coverage, lint clean
- [x] `yarn build` — Vite + tsc declarations succeed
- [x] `yarn typecheck` — no errors
- [x] Error message exactly matches `modifyElement`'s

Closes #126