### PR TITLE
fix(dom): Tolerate null attributes in modifyElement

### DIFF
--- a/src/dom/__tests__/modifyElement.test.ts
+++ b/src/dom/__tests__/modifyElement.test.ts
@@ -94,8 +94,8 @@ describe('modifyElement', () => {
 
 	it('treats null attributes as a no-op', () => {
 		const before = (el as HTMLElement).outerHTML
-		expect(() => modifyElement(el as HTMLElement, null)).not.toThrow()
-		expect(modifyElement(el as HTMLElement, null)).toBe(el)
+		const result = modifyElement(el as HTMLElement, null)
+		expect(result).toBe(el)
 		expect((el as HTMLElement).outerHTML).toBe(before)
 	})
 })

--- a/src/dom/__tests__/modifyElement.test.ts
+++ b/src/dom/__tests__/modifyElement.test.ts
@@ -91,4 +91,11 @@ describe('modifyElement', () => {
 			"Selector '#does-not-exist' did not match any element"
 		)
 	})
+
+	it('treats null attributes as a no-op', () => {
+		const before = (el as HTMLElement).outerHTML
+		expect(() => modifyElement(el as HTMLElement, null)).not.toThrow()
+		expect(modifyElement(el as HTMLElement, null)).toBe(el)
+		expect((el as HTMLElement).outerHTML).toBe(before)
+	})
 })

--- a/src/dom/modifyElement.ts
+++ b/src/dom/modifyElement.ts
@@ -17,13 +17,14 @@ import { isString } from '../string/isString'
  * modifyElement('#missing', { className: 'bar' }) // throws ReferenceError
  *
  * @param element    - The DOM element or selector of the DOM element to modify.
- * @param attributes - The new attributes to set to the DOM element.
+ * @param attributes - The new attributes to set to the DOM element. `null` is treated as a no-op,
+ *                     mirroring the lenient behaviour of `createElement`.
  * @throws {ReferenceError} When `element` is a string selector that does not match any element in the document.
  * @returns The modified DOM element.
  */
 export const modifyElement = (
 	element: HTMLElement | string,
-	attributes: Record<string, string | null | undefined> = {}
+	attributes: Record<string, string | null | undefined> | null = {}
 ): HTMLElement | null => {
 	let el: HTMLElement | null
 	if (isString(element)) {
@@ -32,11 +33,13 @@ export const modifyElement = (
 	} else {
 		el = element
 	}
-	for (const [key, value] of Object.entries(attributes)) {
-		if (value === undefined || value === null) {
-			el?.removeAttribute(key)
-		} else {
-			el?.setAttribute(key, value)
+	if (attributes) {
+		for (const [key, value] of Object.entries(attributes)) {
+			if (value === undefined || value === null) {
+				el?.removeAttribute(key)
+			} else {
+				el?.setAttribute(key, value)
+			}
 		}
 	}
 	return el


### PR DESCRIPTION
## Summary
Passing `null` as the second argument of `modifyElement` used to throw a low-level `TypeError` from inside `Object.entries(null)`. This PR makes `null` a clean no-op, matching the lenient behaviour already implemented in `createElement` (see `createElement.ts:64`).

## Changes
- `modifyElement` now guards the attribute loop with `if (attributes)`, so `null` (and any other falsy non-object) is skipped without throwing.
- Parameter type widened to `Record<string, string | null | undefined> | null = {}`, making the tolerated `null` formally part of the signature.
- JSDoc updated to document the new lenient behaviour and the parity with `createElement`.
- Regression test added: `modifyElement(el, null)` does not throw, returns the same element, and leaves its `outerHTML` unchanged.

## Test plan
- [x] `yarn test:ci` — 290 tests pass, 100% coverage, lint clean
- [x] `yarn build` — Vite + tsc declarations succeed
- [x] `yarn typecheck` — no errors
- [x] Manually verified the previous TypeError reproducer (`modifyElement(el, null)`) now completes silently

Closes #127