### PR TITLE
fix(dom)!: Reject null and undefined element input in modifyElement and removeElement

### DIFF
--- a/src/dom/__tests__/modifyElement.test.ts
+++ b/src/dom/__tests__/modifyElement.test.ts
@@ -65,11 +65,13 @@ describe('modifyElement', () => {
 
 	// prettier-ignore
 	it.each([
-		{
-			name: 'returns undefined if element is null',
-		},
-	])('$name', () => {
-		expect(modifyElement(undefined as unknown as HTMLElement)).toBeUndefined()
+		{ name: 'null',      element: null      },
+		{ name: 'undefined', element: undefined },
+	])('throws TypeError when element is $name', ({ element }) => {
+		expect(() => modifyElement(element as unknown as HTMLElement)).toThrow(TypeError)
+		expect(() => modifyElement(element as unknown as HTMLElement)).toThrow(
+			'element must be a non-null HTMLElement or a string selector'
+		)
 	})
 
 	// prettier-ignore

--- a/src/dom/__tests__/removeElement.test.ts
+++ b/src/dom/__tests__/removeElement.test.ts
@@ -28,8 +28,15 @@ describe('removeElement', () => {
 		expect(removeElement(getElement())).not.toBeInTheDocument()
 	})
 
-	it('returns undefined if element is null', () => {
-		expect(removeElement(null as unknown as HTMLElement)).toBeUndefined()
+	// prettier-ignore
+	it.each([
+		{ name: 'null',      element: null      },
+		{ name: 'undefined', element: undefined },
+	])('throws TypeError when element is $name', ({ element }) => {
+		expect(() => removeElement(element as unknown as HTMLElement)).toThrow(TypeError)
+		expect(() => removeElement(element as unknown as HTMLElement)).toThrow(
+			'element must be a non-null HTMLElement or a string selector'
+		)
 	})
 
 	it('returns the element unchanged when it has no parent', () => {
@@ -50,6 +57,15 @@ describe('removeElement', () => {
 		])('$name throws ReferenceError with the same message on a missing selector', ({ fn }) => {
 			expect(fn).toThrow(ReferenceError)
 			expect(fn).toThrow("Selector '#does-not-exist' did not match any element")
+		})
+
+		// prettier-ignore
+		it.each([
+			{ name: 'removeElement', fn: () => removeElement(null as unknown as HTMLElement) },
+			{ name: 'modifyElement', fn: () => modifyElement(null as unknown as HTMLElement) },
+		])('$name throws TypeError with the same message on null input', ({ fn }) => {
+			expect(fn).toThrow(TypeError)
+			expect(fn).toThrow('element must be a non-null HTMLElement or a string selector')
 		})
 	})
 })

--- a/src/dom/modifyElement.ts
+++ b/src/dom/modifyElement.ts
@@ -15,17 +15,20 @@ import { isString } from '../string/isString'
  *
  * modifyElement(element, { className: 'bar' }) // <div class="bar"></div>
  * modifyElement('#missing', { className: 'bar' }) // throws ReferenceError
+ * modifyElement(null, { className: 'bar' })       // throws TypeError
  *
  * @param element    - The DOM element or selector of the DOM element to modify.
  * @param attributes - The new attributes to set to the DOM element. `null` is treated as a no-op,
  *                     mirroring the lenient behaviour of `createElement`.
+ * @throws {TypeError} When `element` is `null` or `undefined`.
  * @throws {ReferenceError} When `element` is a string selector that does not match any element in the document.
  * @returns The modified DOM element.
  */
 export const modifyElement = (
 	element: HTMLElement | string,
 	attributes: Record<string, string | null | undefined> | null = {}
-): HTMLElement | null => {
+): HTMLElement => {
+	if (element == null) throw new TypeError('element must be a non-null HTMLElement or a string selector')
 	let el: HTMLElement | null
 	if (isString(element)) {
 		el = document.querySelector<HTMLElement>(element)
@@ -36,9 +39,9 @@ export const modifyElement = (
 	if (attributes) {
 		for (const [key, value] of Object.entries(attributes)) {
 			if (value === undefined || value === null) {
-				el?.removeAttribute(key)
+				el.removeAttribute(key)
 			} else {
-				el?.setAttribute(key, value)
+				el.setAttribute(key, value)
 			}
 		}
 	}

--- a/src/dom/removeElement.ts
+++ b/src/dom/removeElement.ts
@@ -15,20 +15,23 @@ import { isString } from '../string/isString'
  *
  * removeElement(element) // returns the detached <div class="foo"></div>
  * removeElement('#missing') // throws ReferenceError
+ * removeElement(null)       // throws TypeError
  *
  * @param element  - The DOM element or the selector of the DOM element to remove.
+ * @throws {TypeError} When `element` is `null` or `undefined`.
  * @throws {ReferenceError} When `element` is a string selector that does not match any element in the document.
- * @returns The removed DOM element, or `undefined` when the input is `null`/`undefined`. An
- *          element with no parent is returned unchanged.
+ * @returns The removed DOM element. An element with no parent is returned unchanged.
  */
-export const removeElement = (element: HTMLElement | string): HTMLElement | undefined => {
-	let el: HTMLElement | null
+export const removeElement = (element: HTMLElement | string): HTMLElement => {
+	if (element == null) throw new TypeError('element must be a non-null HTMLElement or a string selector')
+	let el: HTMLElement
 	if (isString(element)) {
-		el = document.querySelector<HTMLElement>(element)
-		if (el === null) throw new ReferenceError(`Selector '${element}' did not match any element`)
+		const queried = document.querySelector<HTMLElement>(element)
+		if (queried === null) throw new ReferenceError(`Selector '${element}' did not match any element`)
+		el = queried
 	} else {
 		el = element
 	}
-	el?.remove()
-	return el ?? undefined
+	el.remove()
+	return el
 }


### PR DESCRIPTION
## Summary
Closes the contract leak where `modifyElement` and `removeElement` silently returned `undefined` when called with a `null`/`undefined` element, contradicting their declared return types and masking caller bugs. Both functions now throw `TypeError` eagerly at the entry. The change is applied to both sibling helpers in the same PR to preserve the missing-target parity locked by #137.

## Changes
- `modifyElement`: throws `TypeError("element must be a non-null HTMLElement or a string selector")` when `element == null`. Return type tightened from `HTMLElement | null` to `HTMLElement`; the unneeded `el?.` optional chains in the attribute loop are dropped.
- `removeElement`: same guard, same message. Return type tightened from `HTMLElement | undefined` to `HTMLElement`. The detached-element path is preserved (an element with no parent is still returned unchanged after a no-op `remove()`).
- JSDoc for both functions documents the new `@throws {TypeError}` contract and includes a `null` example.
- Tests reshuffled: the obsolete `returns undefined if element is null/undefined` cases are replaced by `it.each` blocks asserting `TypeError` with the exact message, for both `null` and `undefined` inputs.
- Parity block in `removeElement.test.ts` extended to assert that both functions throw `TypeError` with the byte-identical message on null input, in addition to the existing missing-selector parity row.

## ⚠️ Breaking changes
- **`modifyElement(null)` / `modifyElement(undefined)`**: used to return `undefined`, now throws `TypeError`.
- **`removeElement(null)` / `removeElement(undefined)`**: used to return `undefined`, now throws `TypeError`.
- **Migration**: callers relying on the silent `undefined` return must guard the input (`if (element)`), wrap the call in `try/catch`, or stop passing nullish values in the first place. The new behaviour catches bugs at the call site instead of letting them propagate as silent no-ops.

## Test plan
- [x] `yarn test:ci` — 294 tests pass, 100% coverage, lint clean
- [x] `yarn build` — Vite + tsc declarations succeed
- [x] `yarn typecheck` — no errors
- [x] Parity block in `removeElement.test.ts` locks both error contracts (ReferenceError on missing selector + TypeError on null input) across both functions

Closes #128