### PR TITLE
fix(dom): Honor explicit empty-string textContent in createElement

### DIFF
--- a/src/dom/__tests__/createElement.test.ts
+++ b/src/dom/__tests__/createElement.test.ts
@@ -57,6 +57,20 @@ describe('createElement', () => {
 		expect(parent).toContainElement(createElement(values))
 	})
 
+	it('creates an empty text node when textContent is an empty string', () => {
+		const el = createElement({ textContent: '' })
+		expect(el.firstChild).not.toBeNull()
+		expect(el.firstChild?.nodeType).toBe(Node.TEXT_NODE)
+		expect(el.firstChild?.nodeValue).toBe('')
+	})
+
+	it('still prefers content over an empty-string textContent', () => {
+		const child = createElement({ tag: 'span' })
+		const el = createElement({ content: child, textContent: '' })
+		expect(el.firstChild).toBe(child)
+		expect(el.childNodes.length).toBe(1)
+	})
+
 	// prettier-ignore
 	it.each([
 		{

--- a/src/dom/createElement.ts
+++ b/src/dom/createElement.ts
@@ -69,7 +69,7 @@ export const createElement = ({
 	if (content) {
 		el.appendChild(content)
 	}
-	if (textContent && !el.hasChildNodes()) {
+	if (textContent != null && !el.hasChildNodes()) {
 		el.appendChild(document.createTextNode(textContent))
 	}
 	const parentNode = parent || document.querySelector(parentSelector as string)


### PR DESCRIPTION
## Summary
Replaces the truthiness check on `textContent` with an explicit nil-check so that `createElement({ textContent: '' })` produces an element with an empty text node, instead of silently dropping the empty string. The omit-vs-explicit distinction is now symmetric, and the precedence rule that `content` wins over `textContent` is preserved.

## Changes
- `createElement.ts:72`: `if (textContent && !el.hasChildNodes())` → `if (textContent != null && !el.hasChildNodes())`. Single-character semantic shift, no other modifications.
- Two regression tests added:
  - `createElement({ textContent: '' })` now exposes a `firstChild` that is a text node with `nodeValue === ''`.
  - `createElement({ content: child, textContent: '' })` still gives precedence to `content` — the child is the only child node.

## Test plan
- [x] `yarn test:ci` — 296 tests pass, 100% coverage, lint clean
- [x] `yarn build` — Vite + tsc declarations succeed
- [x] `yarn typecheck` — no errors
- [x] `outerHTML` of the empty-string case stays `<div></div>` (the text node is empty), so no visible regression for callers reading rendered HTML

## Notes
Not a breaking change — `outerHTML` is unchanged. The only observable shift is that `hasChildNodes()` now returns `true` when an explicit empty string is passed, which is the desired fix.

Closes #129