### PR TITLE
fix(object): Preserve source-side aliasing in deepMerge

### DIFF
--- a/src/object/__tests__/deepMerge.test.ts
+++ b/src/object/__tests__/deepMerge.test.ts
@@ -220,6 +220,46 @@ describe('deepMerge', () => {
 		})
 	})
 
+	describe('source aliasing', () => {
+		it('preserves aliasing for two source properties sharing the same object reference', () => {
+			const shared = { n: 1 }
+			const result = deepMerge({ a: shared, b: shared }, {}) as { a: object; b: object }
+			expect(result.a).not.toBe(shared)
+			expect(result.a).toBe(result.b)
+		})
+
+		it('preserves aliasing for shared references buried under merged subtrees', () => {
+			const shared = { z: 1 }
+			const source = { a: { sub: shared }, b: { sub: shared } }
+			const target = { a: { keepA: 1 }, b: { keepB: 2 } }
+			const result = deepMerge(source, target) as {
+				a: { sub: object; keepA: number }
+				b: { sub: object; keepB: number }
+			}
+			expect(result.a.sub).not.toBe(shared)
+			expect(result.a.sub).toBe(result.b.sub)
+			expect(result.a.keepA).toBe(1)
+			expect(result.b.keepB).toBe(2)
+		})
+
+		it('preserves aliasing for an object shared between source and target', () => {
+			const shared = { z: 1 }
+			const result = deepMerge({ fromSource: shared }, { fromTarget: shared }) as {
+				fromSource: object
+				fromTarget: object
+			}
+			expect(result.fromSource).not.toBe(shared)
+			expect(result.fromSource).toBe(result.fromTarget)
+		})
+
+		it('preserves aliasing for shared array elements', () => {
+			const shared = { n: 1 }
+			const result = deepMerge({ items: [shared, shared] }, {}) as { items: object[] }
+			expect(result.items[0]).not.toBe(shared)
+			expect(result.items[0]).toBe(result.items[1])
+		})
+	})
+
 	describe('prototype pollution', () => {
 		afterEach(() => {
 			delete (Object.prototype as Record<string, unknown>).polluted

--- a/src/object/deepMerge.ts
+++ b/src/object/deepMerge.ts
@@ -5,7 +5,7 @@
 import { isObject } from './isObject'
 
 /** @private */
-const clone = (value: unknown, seen = new WeakMap<object, unknown>()): unknown => {
+const clone = (value: unknown, seen: WeakMap<object, unknown>): unknown => {
 	if (Array.isArray(value)) {
 		if (seen.has(value)) return seen.get(value)
 		const out: unknown[] = new Array(value.length)
@@ -38,11 +38,11 @@ const merge = (
 	source: Record<string, unknown>,
 	target: Record<string, unknown>,
 	mutate: boolean,
-	seen: WeakMap<object, Record<string, unknown>>
+	seen: WeakMap<object, unknown>
 ): Record<string, unknown> => {
-	const existing = seen.get(source)
+	const existing = seen.get(source) as Record<string, unknown> | undefined
 	if (existing) return existing
-	const result = mutate ? target : (clone(target) as Record<string, unknown>)
+	const result = mutate ? target : (clone(target, seen) as Record<string, unknown>)
 	seen.set(source, result)
 	for (const key of Object.keys(source)) {
 		if (key === '__proto__') continue
@@ -54,10 +54,9 @@ const merge = (
 				seen
 			)
 		} else {
-			result[key] = clone(source[key])
+			result[key] = clone(source[key], seen)
 		}
 	}
-	seen.delete(source)
 	return result
 }
 
@@ -70,8 +69,9 @@ const merge = (
  * const target = { foo: 2, zaz: { juv: 1 }, bar: { gag: 'gag' } }
  * deepMerge(source, target) // { foo: 1, zaz: { juv: 1 }, bar: { gag: [1, 2, 3], pol: { mur: 'mur' } } }
  *
- * Plain objects and arrays are deep-cloned, with circular references preserved. Non-cloneable
- * values (functions, DOM nodes, non-serialisable instances) are copied by reference instead of
+ * Plain objects and arrays are deep-cloned, with circular references preserved. Identical
+ * references in the source produce identical references in the output. Non-cloneable values
+ * (functions, DOM nodes, non-serialisable instances) are copied by reference instead of
  * throwing. `__proto__` keys are ignored to prevent prototype pollution.
  *
  * @param source - The object to merge into the target.


### PR DESCRIPTION
## Summary
Closes the bug where `deepMerge` produced distinct clones for two source properties that share the same object reference. Each inner `clone()` call previously created a fresh `WeakMap`, scoped to a single clone subtree, dropping the aliasing relationship. This PR threads a single `WeakMap` through both `merge()` and `clone()` so identical references in the source produce identical references in the output, matching the behaviour of `structuredClone`.

## Changes
- `clone()` no longer creates its own seen map by default — it now accepts a shared `WeakMap<object, unknown>` parameter.
- `merge()`'s seen map is typed `WeakMap<object, unknown>` (was `WeakMap<object, Record<string, unknown>>`) and is threaded into the two internal `clone()` calls (line 45 target clone, line 57 non-merging assignment).
- The asymmetric `seen.delete(source)` cleanup is removed. With a unified map, retaining the entry preserves aliasing on the merge path too; the map is scoped to a single `deepMerge` call and discarded on return, so retention has no lasting effect beyond the call.
- JSDoc gains one sentence: *"Identical references in the source produce identical references in the output."*

## Test plan
- [x] `yarn test:ci` — 300 tests pass, 100% coverage, lint clean
- [x] `yarn build` — Vite + tsc declarations succeed
- [x] `yarn typecheck` — no errors
- [x] Four new aliasing tests covering: top-level shared reference, shared reference buried under merged subtree, reference shared between source and target, and shared array element

## Notes
Not a breaking change — the fix strictly increases identity preservation. Any caller relying on the previous duplication was relying on a bug, not a documented behaviour. `structuredClone` (the structural-cloning baseline used elsewhere in this file) already preserves aliasing the same way.

Closes #130