### PR TITLE
docs(readme): Correct normalizeMinMax return shape in the utilities list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Every utility is exported both from the package root and per-module at `@untemps
 ### number
 - **`clamp`** — clamp a number between two bounds
 - **`getRandomInteger`** — return a pseudo-random integer in `[min, max]`
-- **`normalizeMinMax`** — return `[min, max]` ensuring `min <= max`
+- **`normalizeMinMax`** — return `{ min, max }` with `min <= max`, swapping the inputs if needed
 
 ### object
 - **`deepClone`** — structured-clone deep copy (functions and DOM nodes are not supported)


### PR DESCRIPTION
## Summary
The README described `normalizeMinMax`'s return as `[min, max]`, which reads as a tuple, while the function actually returns `{ min: number; max: number }`. A reader following the README would write `const [min, max] = normalizeMinMax(a, b)` and get `undefined`s. This PR aligns the README entry with the JSDoc and the source.

## Changes
- `README.md` (number section): `` `normalizeMinMax` — return `[min, max]` ensuring `min <= max` `` →
  `` `normalizeMinMax` — return `{ min, max }` with `min <= max`, swapping the inputs if needed ``.

## Test plan
- [x] `yarn test:ci` — 300 tests pass, 100% coverage, lint clean (no code change, but pre-commit hook ran the full suite)
- [x] Manually compared the new README line against the function's actual `@returns` and `@example` in `src/number/normalizeMinMax.ts`

Closes #131