### PR TITLE
docs(readme): Surface deepClone throws and deepMerge mutate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Every utility is exported both from the package root and per-module at `@untemps
 - **`normalizeMinMax`** — return `{ min, max }` with `min <= max`, swapping the inputs if needed
 
 ### object
-- **`deepClone`** — structured-clone deep copy (functions and DOM nodes are not supported)
-- **`deepMerge`** — recursively merge a source into a target with circular-reference support
+- **`deepClone`** — structured-clone deep copy. **Throws `DataCloneError`** on functions, DOM nodes, or other non-cloneable values. Use `deepMerge` if you need a lenient clone that keeps such values by reference.
+- **`deepMerge`** — recursively merge `source` into `target` with circular-reference support. Pass `true` as the third argument to merge into `target` in place instead of producing a new object.
 - **`isObject`** — check whether a value is a plain object
 
 ### string


### PR DESCRIPTION
## Summary
The README descriptions of `deepClone` and `deepMerge` were missing two pieces of public-API information callers needed: `deepClone` throws `DataCloneError` on non-cloneable values (documented in JSDoc since #123) and `deepMerge` accepts a third `mutate` argument for in-place merges. This PR updates the two object-section bullets to surface both facts.

## Changes
- `README.md` (object section, `deepClone` bullet): now flags the `DataCloneError` throw and points to `deepMerge` as the lenient alternative for callers that need a by-reference fallback.
- `README.md` (object section, `deepMerge` bullet): now documents the third boolean argument that switches to in-place mutation of `target`.

## Test plan
- [x] `yarn test:ci` — 300 tests pass, 100% coverage, lint clean (pre-commit hook ran the full suite)
- [x] Cross-checked the new wording against the JSDoc in `src/object/deepClone.ts` and `src/object/deepMerge.ts`

Closes #132