### PR TITLE
docs(readme): Document modifyElement nullish removal and throw

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Every utility is exported both from the package root and per-module at `@untemps
 - **`getCSSDeclaration`** — find a CSS rule by class name across `document.styleSheets`
 - **`getElement`** — query a DOM element by selector
 - **`isElement`** — check whether a value is a DOM element
-- **`modifyElement`** — set attributes on a DOM element (by reference or selector)
+- **`modifyElement`** — set attributes on a DOM element (by reference or selector). **An attribute whose value is `null` or `undefined` is removed instead of being set**, allowing the same call to add and remove attributes in one pass. Throws `ReferenceError` when a selector matches nothing.
 - **`removeElement`** — remove a DOM element (by reference or selector)
 - **`resolveClassName`** — aggregate class names from strings or `[condition, ifTrue, ifFalse]` tuples
 


### PR DESCRIPTION
## Summary
The README bullet for `modifyElement` described only the setter side of the function, hiding two public behaviours already documented in the JSDoc: a `null` / `undefined` value removes the attribute instead of setting it (exercised by `modifyElement.test.ts:27-43`), and a string selector that matches nothing raises `ReferenceError` (since #119). This PR makes both behaviours discoverable from the README.

## Changes
- `README.md` (dom section, `modifyElement` bullet): now mentions the nullish-removal behaviour ("allowing the same call to add and remove attributes in one pass") and the `ReferenceError` thrown on a missing selector.

## Test plan
- [x] `yarn test:ci` — 300 tests pass, 100% coverage, lint clean (pre-commit hook ran the full suite)
- [x] Cross-checked against the JSDoc in `src/dom/modifyElement.ts` and the relevant test rows

Closes #133