### PR TITLE
chore(dom): Match grouped selectors in getCSSDeclaration

### DIFF
--- a/src/dom/__tests__/getCSSDeclaration.test.ts
+++ b/src/dom/__tests__/getCSSDeclaration.test.ts
@@ -39,6 +39,34 @@ describe('getCSSDeclaration', () => {
 		})
 	})
 
+	describe('Grouped and composed selectors', () => {
+		const setSheet = (cssText: string): void => {
+			const accessibleSheet = {
+				cssRules: [{ selectorText: cssText.match(/^([^{]+)/)?.[1].trim(), style: { cssText: 'color: red;' } }],
+			} as unknown as CSSStyleSheet
+			vi.spyOn(document, 'styleSheets', 'get').mockReturnValue([accessibleSheet] as unknown as StyleSheetList)
+		}
+
+		afterEach(() => {
+			vi.restoreAllMocks()
+		})
+
+		it.each(['drag', '.drag', 'drop', '.drop'])('matches each name in a grouped selector (%s)', (className) => {
+			setSheet('.drag, .drop { color: red; }')
+			expect(getCSSDeclaration(className, true)).toBe('color: red;')
+		})
+
+		it('tolerates extra whitespace around the commas in a grouped selector', () => {
+			setSheet('.drag  ,   .drop { color: red; }')
+			expect(getCSSDeclaration('drop', true)).toBe('color: red;')
+		})
+
+		it('does not match a composed selector that merely contains the class', () => {
+			setSheet('.drag.active { color: red; }')
+			expect(getCSSDeclaration('drag')).toBeNull()
+		})
+	})
+
 	describe('With cross-origin stylesheets', () => {
 		const makeCrossOriginSheet = (): CSSStyleSheet =>
 			({

--- a/src/dom/__tests__/getCSSDeclaration.test.ts
+++ b/src/dom/__tests__/getCSSDeclaration.test.ts
@@ -40,9 +40,9 @@ describe('getCSSDeclaration', () => {
 	})
 
 	describe('Grouped and composed selectors', () => {
-		const setSheet = (cssText: string): void => {
+		const setSheet = (selectorText: string): void => {
 			const accessibleSheet = {
-				cssRules: [{ selectorText: cssText.match(/^([^{]+)/)?.[1].trim(), style: { cssText: 'color: red;' } }],
+				cssRules: [{ selectorText, style: { cssText: 'color: red;' } }],
 			} as unknown as CSSStyleSheet
 			vi.spyOn(document, 'styleSheets', 'get').mockReturnValue([accessibleSheet] as unknown as StyleSheetList)
 		}
@@ -52,17 +52,17 @@ describe('getCSSDeclaration', () => {
 		})
 
 		it.each(['drag', '.drag', 'drop', '.drop'])('matches each name in a grouped selector (%s)', (className) => {
-			setSheet('.drag, .drop { color: red; }')
+			setSheet('.drag, .drop')
 			expect(getCSSDeclaration(className, true)).toBe('color: red;')
 		})
 
 		it('tolerates extra whitespace around the commas in a grouped selector', () => {
-			setSheet('.drag  ,   .drop { color: red; }')
+			setSheet('.drag  ,   .drop')
 			expect(getCSSDeclaration('drop', true)).toBe('color: red;')
 		})
 
 		it('does not match a composed selector that merely contains the class', () => {
-			setSheet('.drag.active { color: red; }')
+			setSheet('.drag.active')
 			expect(getCSSDeclaration('drag')).toBeNull()
 		})
 	})

--- a/src/dom/getCSSDeclaration.ts
+++ b/src/dom/getCSSDeclaration.ts
@@ -15,6 +15,10 @@
  * const returnText = true
  * getCSSDeclaration(className, returnText) // background-color: black;
  *
+ * Matches `className` exactly against any of the comma-separated selectors of a rule (e.g.
+ * `.drag, .other` resolves both `drag` and `other`). Composed selectors such as `.foo.bar`,
+ * `.foo:hover`, or `body .foo` are not unwrapped — use `getComputedStyle` for those.
+ *
  * @param className            - The name of the CSS declaration to return. You may ignore the starting dot.
  * @param returnText  - `true` to get a string representation of the CSS declaration.
  * @returns The CSS declaration or null if the CSS declaration is not found.
@@ -33,7 +37,8 @@ export const getCSSDeclaration = (className: string, returnText = false): CSSSty
 				}
 				for (const rule of rules) {
 					const styleRule = rule as CSSStyleRule
-					if (styleRule.selectorText === className && !!styleRule.style) {
+					const selectors = styleRule.selectorText?.split(',').map((s) => s.trim())
+					if (selectors?.includes(className) && styleRule.style) {
 						return returnText ? styleRule.style.cssText : styleRule.style
 					}
 				}


### PR DESCRIPTION
## Summary
`getCSSDeclaration` compared `styleRule.selectorText === className` strictly, missing rules whose selector is grouped (`.drag, .other`) even when the requested class was one of them. This PR splits the rule's `selectorText` on `,`, trims each piece, and does an `includes()` check. Composed selectors like `.foo.bar` or `.foo:hover` are still not unwrapped — `getComputedStyle` is the right tool for that, and the JSDoc now states the boundary explicitly.

## Changes
- `src/dom/getCSSDeclaration.ts`: matcher rewritten as `selectors.includes(className)` over the comma-split list. `selectorText` is accessed via optional chaining so rule types without it (e.g. `CSSMediaRule`, `CSSImportRule`) are skipped safely. JSDoc gains a paragraph describing the matching scope and the boundary.
- `src/dom/__tests__/getCSSDeclaration.test.ts`: new `Grouped and composed selectors` describe block with three regression cases — grouped match (four parametrised inputs covering both classes, with and without the leading dot), whitespace tolerance around commas, and the documented limitation that `.drag.active` is not matched by `drag`.

## Notes (no breaking change, one subtle observable shift)
Strictly speaking this widens what the function matches. In a stylesheet that contains both a grouped rule and a single-selector rule for the same class, the grouped one — which was previously skipped — is now returned if it comes first. Marginal edge case worth flagging here for completeness, but no documented contract changes.

## Test plan
- [x] `yarn test:ci` — 306 tests pass, 100% coverage, lint clean
- [x] `yarn build` — Vite + tsc declarations succeed
- [x] `yarn typecheck` — no errors
- [x] Existing single-selector tests untouched and still passing — split on `,` of `".drag"` yields `[".drag"]`, which `includes(".drag")` matches

Closes #135