### PR TITLE
ci: Add reusable check workflow and call it from publish

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,13 +20,12 @@ jobs:
       - run: yarn typecheck
       - run: yarn test:ci
       - run: yarn build
+      - uses: codecov/codecov-action@v6.0.0
+        with:
+          files: coverage/lcov.info
       - uses: actions/upload-artifact@v4
+        if: github.event_name == 'push'
         with:
           name: dist
           path: dist
-          retention-days: 1
-      - uses: actions/upload-artifact@v4
-        with:
-          name: coverage
-          path: coverage
           retention-days: 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,9 +22,6 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn typecheck
       - run: yarn test:ci
-      - uses: codecov/codecov-action@v6.0.0
-        with:
-          files: coverage/lcov.info
       - run: yarn build
       - uses: actions/upload-artifact@v4
         if: success() && github.event_name == 'push'
@@ -32,3 +29,7 @@ jobs:
           name: dist
           path: dist
           retention-days: 1
+      - uses: codecov/codecov-action@v6.0.0
+        if: ${{ !cancelled() }}
+        with:
+          files: coverage/lcov.info

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,9 @@ on:
   workflow_call:
 permissions:
   contents: read
+concurrency:
+  group: check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -19,12 +22,12 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn typecheck
       - run: yarn test:ci
-      - run: yarn build
       - uses: codecov/codecov-action@v6.0.0
         with:
           files: coverage/lcov.info
+      - run: yarn build
       - uses: actions/upload-artifact@v4
-        if: github.event_name == 'push'
+        if: success() && github.event_name == 'push'
         with:
           name: dist
           path: dist

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,32 @@
+name: "check"
+on:
+  pull_request:
+    branches:
+      - main
+      - beta
+  workflow_call:
+permissions:
+  contents: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: '24'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn typecheck
+      - run: yarn test:ci
+      - run: yarn build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          retention-days: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage
+          retention-days: 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,14 +8,14 @@ on:
 permissions:
   contents: read
 concurrency:
-  group: check-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'yarn'
@@ -29,7 +29,7 @@ jobs:
           name: dist
           path: dist
           retention-days: 1
-      - uses: codecov/codecov-action@v6.0.0
+      - uses: codecov/codecov-action@v6
         if: ${{ !cancelled() }}
         with:
           files: coverage/lcov.info

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,13 +28,6 @@ jobs:
         with:
           name: dist
           path: dist
-      - uses: actions/download-artifact@v4
-        with:
-          name: coverage
-          path: coverage
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: codecov/codecov-action@v6.0.0
-        with:
-          files: coverage/lcov.info

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,10 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'yarn'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,10 @@ permissions:
     pull-requests: write
     issues: write
 jobs:
+  check:
+    uses: ./.github/workflows/check.yml
   publish:
+    needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
@@ -21,9 +24,14 @@ jobs:
           node-version: '24'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
-      - run: yarn typecheck
-      - run: yarn test:ci
-      - run: yarn build
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage
+          path: coverage
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a dedicated `check` workflow that runs `typecheck`, `test:ci` and `build` on every pull request targeting `main` or `beta`, and refactors `publish.yml` to reuse it via `workflow_call` instead of duplicating the same steps. Versioning behaviour stays untouched — `semantic-release` is still the only step that publishes, only in `publish.yml`, only on push.

## Changes
- New `.github/workflows/check.yml`: triggered on `pull_request` to `main`/`beta` and exposed as a reusable workflow via `workflow_call`. Runs install, typecheck, tests, Codecov upload, then build. On `push` (when called from `publish.yml`) it also uploads `dist/` as an artifact.
- `.github/workflows/publish.yml`: first job now calls `./.github/workflows/check.yml`; the `publish` job depends on it and downloads the `dist` artifact instead of rebuilding/retesting locally.
- Concurrency group on `check.yml` cancels in-progress runs when a new commit lands on the same ref.

## Behaviour changes worth flagging
- **Codecov now uploads on every PR** (previously only on push to `main`/`beta`). This is intentional — it enables Codecov PR comments and status checks. The upload is no longer part of `publish.yml`.
- **No coverage artifact** is uploaded or downloaded; only `dist/` is shared between `check` and `publish`.

## Test plan
- [ ] Open this PR and confirm the `check` workflow runs and passes against `beta`.
- [ ] Confirm Codecov receives the PR upload.
- [ ] After merge to `beta`, confirm `publish.yml` runs the `check` job first, then `publish` (semantic-release) without re-running typecheck/test/build.
- [ ] Confirm a new beta version is published as before.

Closes #146
