### PR TITLE
fix(dom): Harmonize null/undefined attribute handling in createElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Every utility is exported both from the package root and per-module at `@untemps
 - **`throttle`** — invoke at most once per interval (leading + trailing); returns a function with `.cancel()`
 
 ### dom
-- **`createElement`** — create a DOM element from a configuration object
+- **`createElement`** — create a DOM element from a configuration object. **Attributes whose value is `null` or `undefined` are ignored** (no-op for those keys), mirroring `modifyElement`
 - **`doElementsOverlap`** — check whether two DOM elements overlap on screen
 - **`getCSSDeclaration`** — find a CSS rule by class name across `document.styleSheets`
 - **`getElement`** — query a DOM element by selector

--- a/src/dom/__tests__/createElement.test.ts
+++ b/src/dom/__tests__/createElement.test.ts
@@ -24,6 +24,11 @@ describe('createElement', () => {
 			expected: '<div></div>',
 		},
 		{
+			name: 'ignores attributes with null or undefined values',
+			values: { attributes: { id: 'foo', 'aria-label': null, 'data-foo': undefined } },
+			expected: '<div id="foo"></div>',
+		},
+		{
 			name: 'creates element with content',
 			values: { content: createElement({ tag: 'span' }) },
 			expected: '<div><span></span></div>',

--- a/src/dom/createElement.ts
+++ b/src/dom/createElement.ts
@@ -48,6 +48,10 @@ export interface CreateElementConfig {
  *  parentSelector: 'body'
  * }) // <p id="foo" style="font-weight: bold">Foo</p>
  *
+ * @remarks
+ * Attribute keys whose value is `null` or `undefined` are ignored, matching `modifyElement`'s
+ * lenient behaviour. This makes it safe to reuse the same configuration object across both APIs.
+ *
  * @param config - The configuration object for the new DOM element.
  * @returns The new DOM element.
  */

--- a/src/dom/createElement.ts
+++ b/src/dom/createElement.ts
@@ -22,8 +22,8 @@ export interface BoundingClientRectInit {
 export interface CreateElementConfig {
 	/** The tag name of the new DOM element to create. All valid HTML tags are accepted. */
 	tag?: string
-	/** The attributes to pass to the new DOM element. */
-	attributes?: Record<string, string> | null
+	/** The attributes to pass to the new DOM element. Keys whose value is `null` or `undefined` are ignored. */
+	attributes?: Record<string, string | null | undefined> | null
 	/** A DOM element to append as child. Has precedence over textContent. */
 	content?: HTMLElement | null
 	/** A text to append as child of the new DOM element. */
@@ -63,6 +63,7 @@ export const createElement = ({
 	const el = document.createElement(tag)
 	if (attributes) {
 		for (const [key, value] of Object.entries(attributes)) {
+			if (value === undefined || value === null) continue
 			el.setAttribute(key, value)
 		}
 	}


### PR DESCRIPTION
## Summary
`createElement` used to forward `null`/`undefined` attribute values straight to `setAttribute`, producing literal `"null"`/`"undefined"` strings. This PR aligns it with `modifyElement` by silently dropping nullish keys, and widens the `attributes` type so the lenient contract is part of the public API.

## Changes
- `src/dom/createElement.ts` — skip attribute entries whose value is `null` or `undefined`; type `attributes` as `Record<string, string | null | undefined> | null`.
- `src/dom/__tests__/createElement.test.ts` — add a fixture row asserting that nullish values are ignored while truthy ones still land.
- `README.md` + JSDoc — document the new behavior so the harmonization with `modifyElement` is visible.

## Test plan
- [x] `yarn test:ci` (vitest + coverage + lint) green, 100% coverage preserved
- [x] `yarn build` (Vite + `tsc -p tsconfig.build.json`) green
- [x] `yarn typecheck` green
- [x] Reviewer: confirm the wording of the README bullet reads well alongside the existing `modifyElement` blurb

Closes #147