### PR TITLE
fix(dom)!: Snapshot getCSSDeclaration return to prevent live stylesheet mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Every utility is exported both from the package root and per-module at `@untemps
 ### dom
 - **`createElement`** — create a DOM element from a configuration object. **Attributes whose value is `null` or `undefined` are ignored** (no-op for those keys), mirroring `modifyElement`
 - **`doElementsOverlap`** — check whether two DOM elements overlap on screen
-- **`getCSSDeclaration`** — find a CSS rule by class name across `document.styleSheets`
+- **`getCSSDeclaration`** — find a CSS rule by class name across `document.styleSheets`. Returns a **snapshot `Record<string, string>`** of the declared properties (kebab-case keys, mirroring the CSS Object Model); mutating it has no effect on the live stylesheet. Pass `returnText = true` to get the raw `cssText` string instead.
 - **`getElement`** — query a DOM element by selector
 - **`isElement`** — check whether a value is a DOM element
 - **`modifyElement`** — set attributes on a DOM element (by reference or selector). **An attribute whose value is `null` or `undefined` is removed instead of being set**, allowing the same call to add and remove attributes in one pass. Throws `ReferenceError` when a selector matches nothing.

--- a/src/dom/__tests__/getCSSDeclaration.test.ts
+++ b/src/dom/__tests__/getCSSDeclaration.test.ts
@@ -31,11 +31,17 @@ describe('getCSSDeclaration', () => {
 		})
 
 		it.each(['drag', '.drag'])('Returns declaration', (className) => {
-			expect(getCSSDeclaration(className)).toHaveLength(1)
+			expect(getCSSDeclaration(className)).toEqual({ 'background-color': 'black' })
 		})
 
 		it('Returns declaration', () => {
 			expect(getCSSDeclaration('drag', true)).toBe('background-color: black;')
+		})
+
+		it('Returns a snapshot that does not mutate the source rule', () => {
+			const decl = getCSSDeclaration('drag') as Record<string, string>
+			decl['background-color'] = 'red'
+			expect(getCSSDeclaration('drag')).toEqual({ 'background-color': 'black' })
 		})
 	})
 

--- a/src/dom/getCSSDeclaration.ts
+++ b/src/dom/getCSSDeclaration.ts
@@ -2,6 +2,15 @@
  * @module dom/getCSSDeclaration
  */
 
+const snapshot = (style: CSSStyleDeclaration): Record<string, string> => {
+	const result: Record<string, string> = {}
+	for (let i = 0; i < style.length; i++) {
+		const property = style[i]
+		result[property] = style.getPropertyValue(property)
+	}
+	return result
+}
+
 /**
  * @function
  * @example
@@ -12,18 +21,22 @@
  * document.head.appendChild(styleElement)
  *
  * const className = '.drag'
- * const returnText = true
- * getCSSDeclaration(className, returnText) // background-color: black;
+ * getCSSDeclaration(className) // { 'background-color': 'black' }
+ * getCSSDeclaration(className, true) // 'background-color: black;'
  *
  * Matches `className` exactly against any of the comma-separated selectors of a rule (e.g.
  * `.drag, .other` resolves both `drag` and `other`). Composed selectors such as `.foo.bar`,
  * `.foo:hover`, or `body .foo` are not unwrapped — use `getComputedStyle` for those.
  *
- * @param className            - The name of the CSS declaration to return. You may ignore the starting dot.
- * @param returnText  - `true` to get a string representation of the CSS declaration.
- * @returns The CSS declaration or null if the CSS declaration is not found.
+ * The returned object is a snapshot of the matched rule's declared properties (kebab-case
+ * keys, as produced by the CSS Object Model). Mutating it has no effect on the live
+ * stylesheet; to update the rule itself, reach for `document.styleSheets` directly.
+ *
+ * @param className   - The name of the CSS declaration to return. You may ignore the starting dot.
+ * @param returnText  - `true` to get the rule's `cssText` string instead of the snapshot object.
+ * @returns The snapshot, the `cssText` string, or `null` if no rule matches.
  */
-export const getCSSDeclaration = (className: string, returnText = false): CSSStyleDeclaration | string | null => {
+export const getCSSDeclaration = (className: string, returnText = false): Record<string, string> | string | null => {
 	if (className) {
 		className = className.startsWith('.') ? className : `.${className}`
 		if (document.styleSheets?.length) {
@@ -39,7 +52,7 @@ export const getCSSDeclaration = (className: string, returnText = false): CSSSty
 					const styleRule = rule as CSSStyleRule
 					const selectors = styleRule.selectorText?.split(',').map((s) => s.trim())
 					if (selectors?.includes(className) && styleRule.style) {
-						return returnText ? styleRule.style.cssText : styleRule.style
+						return returnText ? styleRule.style.cssText : snapshot(styleRule.style)
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
`getCSSDeclaration` with the default `returnText = false` used to return the live `CSSStyleDeclaration` owned by the matched rule, so any caller mutating the result silently changed the stylesheet and every element it applied to. The default mode now returns a plain `Record<string, string>` snapshot built from the rule's declared properties (kebab-case keys mirroring the CSS Object Model). `returnText = true` keeps producing the rule's `cssText` string.

## Changes
- `src/dom/getCSSDeclaration.ts` — added a `snapshot` helper that iterates `style.length` / `style[i]` + `getPropertyValue`, narrowed the return type to `Record<string, string> | string | null`, and refreshed the JSDoc + example to document the snapshot semantics.
- `src/dom/__tests__/getCSSDeclaration.test.ts` — replaced the `toHaveLength(1)` assertion with a `toEqual({ 'background-color': 'black' })` check and added a "snapshot does not mutate the source rule" case.
- `README.md` — surfaced the snapshot shape and the `returnText` option in the utilities list, matching the existing `createElement` / `modifyElement` entries.

## Test plan
- [ ] `yarn test:ci` — coverage stays at 100% across all files
- [ ] `yarn build` — Vite + tsc emit complete with no warnings
- [ ] `yarn typecheck` — passes
- [ ] Manual sanity: `getCSSDeclaration('drag')` in a sandboxed page returns a plain object whose mutation does not affect the matched rule on a subsequent call

## ⚠️ Breaking changes
- **Return type narrows**: `Record<string, string> | string | null` replaces `CSSStyleDeclaration | string | null` for the default mode. Callers using DOM methods (`getPropertyValue`, `setProperty`, …) on the result must either pass `returnText = true` and parse the string, switch to `getComputedStyle` for reads, or mutate the stylesheet directly via `document.styleSheets`.
- **Mutation no longer propagates**: previously, mutating the returned `CSSStyleDeclaration` modified the live rule. Any consumer that relied on that side effect must now apply the change explicitly.

Closes #149