### PR TITLE
refactor(object)!: Infer DeepMerge return type from source and target

### DIFF
--- a/src/object/__tests__/deepMerge.test.ts
+++ b/src/object/__tests__/deepMerge.test.ts
@@ -78,7 +78,7 @@ describe('deepMerge', () => {
 			const source = { items }
 			const result = deepMerge(source, {})
 			expect(result.items).not.toBe(items)
-			;(result.items as number[]).push(3)
+			result.items.push(3)
 			expect(items).toEqual([1, 2])
 		})
 
@@ -111,7 +111,7 @@ describe('deepMerge', () => {
 			const source = { items }
 			const result = deepMerge(source, { items: 'old' })
 			expect(result.items).not.toBe(items)
-			;(result.items as number[]).push(3)
+			result.items.push(3)
 			expect(items).toEqual([1, 2])
 		})
 
@@ -140,7 +140,7 @@ describe('deepMerge', () => {
 		it('copies a function nested in a source object by reference', () => {
 			const fn = () => 1
 			const result = deepMerge({ a: { fn } }, {})
-			expect((result.a as { fn: () => number }).fn).toBe(fn)
+			expect(result.a.fn).toBe(fn)
 		})
 
 		it('keeps a non-cloneable class instance by reference instead of throwing', () => {
@@ -223,7 +223,7 @@ describe('deepMerge', () => {
 	describe('source aliasing', () => {
 		it('preserves aliasing for two source properties sharing the same object reference', () => {
 			const shared = { n: 1 }
-			const result = deepMerge({ a: shared, b: shared }, {}) as { a: object; b: object }
+			const result = deepMerge({ a: shared, b: shared }, {})
 			expect(result.a).not.toBe(shared)
 			expect(result.a).toBe(result.b)
 		})
@@ -232,10 +232,7 @@ describe('deepMerge', () => {
 			const shared = { z: 1 }
 			const source = { a: { sub: shared }, b: { sub: shared } }
 			const target = { a: { keepA: 1 }, b: { keepB: 2 } }
-			const result = deepMerge(source, target) as {
-				a: { sub: object; keepA: number }
-				b: { sub: object; keepB: number }
-			}
+			const result = deepMerge(source, target)
 			expect(result.a.sub).not.toBe(shared)
 			expect(result.a.sub).toBe(result.b.sub)
 			expect(result.a.keepA).toBe(1)
@@ -244,17 +241,14 @@ describe('deepMerge', () => {
 
 		it('preserves aliasing for an object shared between source and target', () => {
 			const shared = { z: 1 }
-			const result = deepMerge({ fromSource: shared }, { fromTarget: shared }) as {
-				fromSource: object
-				fromTarget: object
-			}
+			const result = deepMerge({ fromSource: shared }, { fromTarget: shared })
 			expect(result.fromSource).not.toBe(shared)
 			expect(result.fromSource).toBe(result.fromTarget)
 		})
 
 		it('preserves aliasing for shared array elements', () => {
 			const shared = { n: 1 }
-			const result = deepMerge({ items: [shared, shared] }, {}) as { items: object[] }
+			const result = deepMerge({ items: [shared, shared] }, {})
 			expect(result.items[0]).not.toBe(shared)
 			expect(result.items[0]).toBe(result.items[1])
 		})
@@ -343,6 +337,51 @@ describe('deepMerge', () => {
 			const target: Record<string, unknown> = {}
 			deepMerge({ fn }, target, true)
 			expect(target.fn).toBe(fn)
+		})
+	})
+
+	describe('typing', () => {
+		it('infers disjoint source and target keys', () => {
+			const result = deepMerge({ foo: 1 }, { bar: 'x' })
+			expectTypeOf(result).toEqualTypeOf<{ foo: number; bar: string }>()
+		})
+
+		it('lets source win on overlapping primitive keys', () => {
+			const result = deepMerge({ foo: 1 }, { foo: 'x' })
+			expectTypeOf(result).toEqualTypeOf<{ foo: number }>()
+		})
+
+		it('recursively merges nested plain objects', () => {
+			const source = { bar: { gag: 1 } }
+			const target = { bar: { pol: 'mur' } }
+			const result = deepMerge(source, target)
+			expectTypeOf(result).toEqualTypeOf<{ bar: { gag: number; pol: string } }>()
+		})
+
+		it('replaces arrays instead of merging them', () => {
+			const result = deepMerge({ items: [1, 2] }, { items: [3, 4, 5] })
+			expectTypeOf(result).toEqualTypeOf<{ items: number[] }>()
+		})
+
+		it('lets a source primitive override a target plain object', () => {
+			const result = deepMerge({ a: 5 }, { a: { b: 1 } })
+			expectTypeOf(result).toEqualTypeOf<{ a: number }>()
+		})
+
+		it('preserves the inferred return type when mutate is true', () => {
+			const result = deepMerge({ foo: 1 }, { bar: 2 }, true)
+			expectTypeOf(result).toEqualTypeOf<{ foo: number; bar: number }>()
+		})
+
+		it('infers a realistic config merge', () => {
+			const defaults = { server: { host: 'localhost', port: 8080 }, debug: false }
+			const userConfig = { server: { port: 9090 }, logLevel: 'info' }
+			const result = deepMerge(userConfig, defaults)
+			expectTypeOf(result).toEqualTypeOf<{
+				server: { host: string; port: number }
+				debug: boolean
+				logLevel: string
+			}>()
 		})
 	})
 })

--- a/src/object/deepMerge.ts
+++ b/src/object/deepMerge.ts
@@ -60,6 +60,45 @@ const merge = (
 	return result
 }
 
+/** @private */
+type IsPlainObject<T> = [T] extends [object]
+	? [T] extends [readonly unknown[]]
+		? false
+		: [T] extends [(...args: never[]) => unknown]
+			? false
+			: [T] extends [
+						| Date
+						| RegExp
+						| Map<unknown, unknown>
+						| Set<unknown>
+						| WeakMap<object, unknown>
+						| WeakSet<object>,
+				  ]
+				? false
+				: true
+	: false
+
+/**
+ * Type of the value returned by {@link deepMerge}.
+ *
+ * Mirrors the runtime semantics of the merge: source keys win on conflicts,
+ * nested plain objects are merged recursively, and arrays, `Date`, `Map`, `Set`,
+ * `RegExp`, `WeakMap`, `WeakSet` and functions are replaced wholesale.
+ */
+export type DeepMerge<S, T> = {
+	[K in keyof S | keyof T]: K extends keyof S
+		? K extends keyof T
+			? IsPlainObject<S[K]> extends true
+				? IsPlainObject<T[K]> extends true
+					? DeepMerge<S[K], T[K]>
+					: S[K]
+				: S[K]
+			: S[K]
+		: K extends keyof T
+			? T[K]
+			: never
+}
+
 /**
  * @function
  * @example
@@ -67,20 +106,26 @@ const merge = (
  *
  * const source = { foo: 1, bar: { gag: [1, 2, 3], pol: { mur: 'mur' } } }
  * const target = { foo: 2, zaz: { juv: 1 }, bar: { gag: 'gag' } }
- * deepMerge(source, target) // { foo: 1, zaz: { juv: 1 }, bar: { gag: [1, 2, 3], pol: { mur: 'mur' } } }
+ * deepMerge(source, target)
+ * // returns { foo: 1, zaz: { juv: 1 }, bar: { gag: [1, 2, 3], pol: { mur: 'mur' } } }
+ * // inferred as { foo: number; bar: { gag: number[]; pol: { mur: string } }; zaz: { juv: number } }
  *
  * Plain objects and arrays are deep-cloned, with circular references preserved. Identical
  * references in the source produce identical references in the output. Non-cloneable values
  * (functions, DOM nodes, non-serialisable instances) are copied by reference instead of
  * throwing. `__proto__` keys are ignored to prevent prototype pollution.
  *
+ * The return type is inferred from `source` and `target`: source keys win on conflicts,
+ * nested plain objects are merged recursively in the type, and arrays/Date/Map/Set/RegExp
+ * and other non-plain values are replaced wholesale (mirroring the runtime semantics).
+ *
  * @param source - The object to merge into the target.
  * @param target - The target object where source will be merged.
  * @param mutate - If true, merges directly into target without cloning. Defaults to false.
  * @returns The merged object — a new object when mutate is false, target itself when mutate is true.
  */
-export const deepMerge = (
-	source: Record<string, unknown>,
-	target: Record<string, unknown>,
+export const deepMerge = <S extends Record<string, unknown>, T extends Record<string, unknown>>(
+	source: S,
+	target: T,
 	mutate = false
-): Record<string, unknown> => merge(source, target, mutate, new WeakMap())
+): DeepMerge<S, T> => merge(source, target, mutate, new WeakMap()) as DeepMerge<S, T>


### PR DESCRIPTION
## Summary
Replaces `deepMerge`'s opaque `Record<string, unknown>` return type with a recursive `DeepMerge<S, T>` that mirrors the runtime merge: source keys win on conflicts, nested plain objects are merged recursively in the type, and arrays, `Date`, `Map`, `Set`, `RegExp`, `WeakMap`, `WeakSet` and functions are replaced wholesale. Callers no longer need a cast on every downstream property access.

## Changes
- `src/object/deepMerge.ts` — internal `IsPlainObject<T>` helper, public `DeepMerge<S, T>` type, generic signature `deepMerge<S, T>(source, target, mutate?): DeepMerge<S, T>`, expanded JSDoc.
- `src/object/__tests__/deepMerge.test.ts` — new `typing` block with `expectTypeOf` assertions (disjoint keys, source-wins conflict, recursive nested merge, array replacement, primitive-over-object, mutate-true return type, realistic config merge). Removed casts in the source-aliasing and non-plain-object tests that are no longer needed.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn test:ci` (315 tests passing, 100% coverage maintained)
- [x] `yarn build` (generated `dist/object/deepMerge.d.ts` exposes the new generic signature)
- [x] `expectTypeOf` assertions enforce the new return type at compile time

## ⚠️ Breaking changes
- **`deepMerge` return type** — was `Record<string, unknown>`, is now `DeepMerge<S, T>` inferred from the argument types. The result is strictly narrower than `Record<string, unknown>`, so consumers that explicitly annotated the call site (e.g. `const x: Record<string, unknown> = deepMerge(...)`) or piped the result into a `Record<string, unknown>`-typed variable will see new type errors.
- Migration: drop the explicit annotation and let TypeScript infer the merged shape. If the wider type is still required, cast at the call site with `as Record<string, unknown>`.

Closes #151