### PR TITLE
chore: Bump CodeQL actions to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,11 +46,11 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
The weekly scheduled CodeQL run failed with `Requires authentication` and ran on deprecated Node 20 actions. This bumps `github/codeql-action/init` and `analyze` from `@v3` to `@v4`, moving them onto Node 24 and the supported major version.

## Changes
- `.github/workflows/codeql.yml`: `codeql-action/init@v3` → `@v4` and `codeql-action/analyze@v3` → `@v4`

## Context
The permission block (`contents: read` + `security-events: write`) is already correct and unchanged — the `Requires authentication` failure was a transient `GITHUB_TOKEN` hiccup at upload time, not a misconfiguration. The actionable fix is the version bump, which resolves both deprecations:
- **Node 20** — forced to Node 24 on 2026-06-16, removed from runners 2026-09-16
- **CodeQL Action v3** — deprecated December 2026

## Test plan
- [ ] CI checks pass on the PR
- [ ] CodeQL run on this PR completes with no Node 20 deprecation warnings
- [ ] After merge, the scheduled/push CodeQL run uploads results successfully

Closes #160